### PR TITLE
QTZ-483 - If JobListener throws an Exception, job is blocked indefinitely

### DIFF
--- a/quartz-core/src/main/java/org/quartz/core/JobRunShell.java
+++ b/quartz-core/src/main/java/org/quartz/core/JobRunShell.java
@@ -171,6 +171,8 @@ public class JobRunShell extends SchedulerListenerSupport implements Runnable {
                 // notify job & trigger listeners...
                 try {
                     if (!notifyListenersBeginning(jec)) {
+                    	CompletedExecutionInstruction instCode = trigger.executionComplete(jec, null);
+                    	qs.notifyJobStoreJobComplete(trigger, jobDetail, instCode);
                         break;
                     }
                 } catch(VetoedException ve) {
@@ -222,6 +224,8 @@ public class JobRunShell extends SchedulerListenerSupport implements Runnable {
 
                 // notify all job listeners
                 if (!notifyJobListenersComplete(jec, jobExEx)) {
+                	CompletedExecutionInstruction instCode = trigger.executionComplete(jec, jobExEx);
+                	qs.notifyJobStoreJobComplete(trigger, jobDetail, instCode);
                     break;
                 }
 

--- a/quartz-core/src/test/java/org/quartz/integrations/tests/NonConcurrentTrackingJob.java
+++ b/quartz-core/src/test/java/org/quartz/integrations/tests/NonConcurrentTrackingJob.java
@@ -1,0 +1,8 @@
+package org.quartz.integrations.tests;
+
+import org.quartz.DisallowConcurrentExecution;
+
+@DisallowConcurrentExecution
+public class NonConcurrentTrackingJob extends TrackingJob {
+
+}

--- a/quartz-core/src/test/java/org/quartz/integrations/tests/QuartzMemoryCronTriggerTest.java
+++ b/quartz-core/src/test/java/org/quartz/integrations/tests/QuartzMemoryCronTriggerTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 import org.quartz.*;
@@ -58,5 +59,175 @@ public class QuartzMemoryCronTriggerTest extends QuartzMemoryTestSupport {
         for (int i = 1; i < times.length; i++) {
           assertThat(times[i], is(baseline + TimeUnit.SECONDS.toMillis(i)));
         }
+    }
+    
+    @Test
+    public void testCronRepeatCountWithJobListener() throws Exception {
+        CronTrigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity("test")
+                .withSchedule(CronScheduleBuilder.cronSchedule("* * * * * ?"))
+                .build();
+        List<Long> scheduledTimes = Collections.synchronizedList(new LinkedList<Long>());
+        scheduler.getContext().put(SCHEDULED_TIMES_KEY, scheduledTimes);
+        JobDetail jobDetail = JobBuilder.newJob(NonConcurrentTrackingJob.class).withIdentity("test").build();
+        scheduler.scheduleJob(jobDetail, trigger);
+        final AtomicInteger count = new AtomicInteger(0);
+        scheduler.getListenerManager().addJobListener(new JobListener() {
+            
+            @Override
+            public void jobWasExecuted(JobExecutionContext context,
+                    JobExecutionException jobException) {
+                count.set(count.get()+1);
+                
+            }
+            
+            @Override
+            public void jobToBeExecuted(JobExecutionContext context) {
+                count.set(count.get()+1);
+                
+            }
+            
+            @Override
+            public void jobExecutionVetoed(JobExecutionContext context) {
+                count.set(count.get()+1);
+                
+            }
+            
+            @Override
+            public String getName() {
+                return "testjoblistener";
+            }
+        });
+
+        for (int i = 0; i < 20 && scheduledTimes.size() < 3; i++) {
+          Thread.sleep(500);
+        }
+        assertThat(count.get(), is(3*2));
+        
+        assertThat(scheduledTimes, hasSize(greaterThanOrEqualTo(3)));
+
+        Long[] times = scheduledTimes.toArray(new Long[scheduledTimes.size()]);
+        
+        long baseline = times[0];
+        assertThat(baseline % 1000, is(0L));
+        for (int i = 1; i < times.length; i++) {
+          assertThat(times[i], is(baseline + TimeUnit.SECONDS.toMillis(i)));
+        }
+
+    }
+    
+    @Test
+    public void testShouldNotStayBlockedOnJobListenerExceptionBeforeExecution() throws Exception {
+        CronTrigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity("test")
+                .withSchedule(CronScheduleBuilder.cronSchedule("* * * * * ?"))
+                .build();
+        final List<Long> scheduledTimes = Collections.synchronizedList(new LinkedList<Long>());
+        scheduler.getContext().put(SCHEDULED_TIMES_KEY, scheduledTimes);
+        JobDetail jobDetail = JobBuilder.newJob(NonConcurrentTrackingJob.class).withIdentity("test").build();
+        scheduler.scheduleJob(jobDetail, trigger);
+        final AtomicInteger count = new AtomicInteger(0);
+        scheduler.getListenerManager().addJobListener(new JobListener() {
+            
+            @Override
+            public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+                count.set(count.get()+1);
+            }
+            
+            @Override
+            public void jobToBeExecuted(JobExecutionContext context) {
+                count.set(count.get()+1);
+                
+                if (count.get() == 3){
+                    throw new RuntimeException("failing job execution #2");
+                }
+            }
+            
+            @Override
+            public void jobExecutionVetoed(JobExecutionContext context) {
+                count.set(count.get()+1);
+            }
+            
+            @Override
+            public String getName() {
+                return "testjoblistener";
+            }
+        });
+
+        for (int i = 0; i < 20 && scheduledTimes.size() < 3; i++) {
+          Thread.sleep(500);
+        }
+        assertThat(count.get(), is(3*2+1));
+        
+        assertThat(scheduledTimes, hasSize(greaterThanOrEqualTo(3)));
+
+        Long[] times = scheduledTimes.toArray(new Long[scheduledTimes.size()]);
+        
+        long baseline = times[0];
+        assertThat(baseline % 1000, is(0L));
+        
+        // first successful execution: #1 try
+        assertThat(times[0], is(baseline + TimeUnit.SECONDS.toMillis(0)));
+        // second successful execution: #2 try was a failure, then #3 try success
+        assertThat(times[1], is(baseline + TimeUnit.SECONDS.toMillis(2)));
+        // third successful execution: #4 try
+        assertThat(times[2], is(baseline + TimeUnit.SECONDS.toMillis(3)));
+    }
+    
+    @Test
+    public void testShouldNotStayBlockedOnJobListenerExceptionAfterExecution() throws Exception {
+        CronTrigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity("test")
+                .withSchedule(CronScheduleBuilder.cronSchedule("* * * * * ?"))
+                .build();
+        final List<Long> scheduledTimes = Collections.synchronizedList(new LinkedList<Long>());
+        scheduler.getContext().put(SCHEDULED_TIMES_KEY, scheduledTimes);
+        JobDetail jobDetail = JobBuilder.newJob(NonConcurrentTrackingJob.class).withIdentity("test").build();
+        scheduler.scheduleJob(jobDetail, trigger);
+        final AtomicInteger count = new AtomicInteger(0);
+        scheduler.getListenerManager().addJobListener(new JobListener() {
+            
+            @Override
+            public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+                count.set(count.get()+1);
+                if (count.get() == 4){
+                    throw new RuntimeException("failing job execution #2");
+                }
+            }
+            
+            @Override
+            public void jobToBeExecuted(JobExecutionContext context) {
+                count.set(count.get()+1);
+            }
+            
+            @Override
+            public void jobExecutionVetoed(JobExecutionContext context) {
+                count.set(count.get()+1);
+            }
+            
+            @Override
+            public String getName() {
+                return "testjoblistener";
+            }
+        });
+
+        for (int i = 0; i < 20 && scheduledTimes.size() < 3; i++) {
+          Thread.sleep(500);
+        }
+        assertThat(count.get(), is(3*2));
+        
+        assertThat(scheduledTimes, hasSize(greaterThanOrEqualTo(3)));
+
+        Long[] times = scheduledTimes.toArray(new Long[scheduledTimes.size()]);
+        
+        long baseline = times[0];
+        assertThat(baseline % 1000, is(0L));
+        
+        // first successful execution: #1 try
+        assertThat(times[0], is(baseline + TimeUnit.SECONDS.toMillis(0)));
+        // second successful execution: #2 try was a success (only failed to notify of completion) 
+        assertThat(times[1], is(baseline + TimeUnit.SECONDS.toMillis(1)));
+        // third successful execution: #3 try
+        assertThat(times[2], is(baseline + TimeUnit.SECONDS.toMillis(2)));
     }
 }


### PR DESCRIPTION
This relates to the issue reported in https://jira.terracotta.org/jira/browse/QTZ-483.

I've found this to be a problem especially when using the DisallowConcurrentExecution annotation, since with it, as soon as any exception is throw by the Job Listener, the current job is left blocked and no other jobs are allowed to run afterwards.

I've fixed the issue for JobListeners in JobRunShell, however this might also occur when using TriggerListeners (line 248). Since I had no previous issues with them I did not test that specific case or made any further changes.
