### PR TITLE
Exclude discardIdleConnectionsSeconds

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/StdSchedulerFactory.java
+++ b/quartz-core/src/main/java/org/quartz/impl/StdSchedulerFactory.java
@@ -1365,6 +1365,7 @@ public class StdSchedulerFactory implements SchedulerFactory {
         copyProps.remove(PoolingConnectionProvider.DB_MAX_CACHED_STATEMENTS_PER_CONNECTION);
         copyProps.remove(PoolingConnectionProvider.DB_VALIDATE_ON_CHECKOUT);
         copyProps.remove(PoolingConnectionProvider.DB_VALIDATION_QUERY);
+        copyProps.remove(PoolingConnectionProvider.DB_DISCARD_IDLE_CONNECTIONS_SECONDS);
         setBeanProps(cp.getDataSource(), copyProps);
     }
 

--- a/quartz-core/src/main/java/org/quartz/utils/PoolingConnectionProvider.java
+++ b/quartz-core/src/main/java/org/quartz/utils/PoolingConnectionProvider.java
@@ -96,7 +96,7 @@ public class PoolingConnectionProvider implements ConnectionProvider {
     public static final String DB_VALIDATE_ON_CHECKOUT = "validateOnCheckout";
     
     /** Discard connections after they have been idle this many seconds.  0 disables the feature. Default is 0.*/ 
-    private static final String DB_DISCARD_IDLE_CONNECTIONS_SECONDS = "discardIdleConnectionsSeconds"; 
+    public static final String DB_DISCARD_IDLE_CONNECTIONS_SECONDS = "discardIdleConnectionsSeconds";
 
     /** Default maximum number of database connections in the pool. */
     public static final int DEFAULT_DB_MAX_CONNECTIONS = 10;

--- a/quartz-core/src/test/java/org/quartz/utils/PoolingConnectionProviderTest.java
+++ b/quartz-core/src/test/java/org/quartz/utils/PoolingConnectionProviderTest.java
@@ -100,6 +100,7 @@ public class PoolingConnectionProviderTest extends QuartzDatabaseTestSupport {
         properties.put("org.quartz.dataSource.myDS.acquireIncrement","5");
         properties.put("org.quartz.dataSource.myDS.acquireRetryAttempts","3");
         properties.put("org.quartz.dataSource.myDS.acquireRetryDelay","3000");
+        properties.put("org.quartz.dataSource.myDS.discardIdleConnectionsSeconds","60");
 
         return properties;
     }


### PR DESCRIPTION
_Migrated from [QTZ-499](https://jira.terracotta.org/jira/browse/QTZ-499)._

Quartz currently throws `java.lang.NoSuchMethodException: No setter for property 'discardIdleConnectionsSeconds'` when `discardIdleConnectionsSeconds` is defined in a datasource.

This adds `discardIdleConnectionsSeconds` to the other excludes so it doesn't fail when `setBeanProps` is called.

**Example**

`org.quartz.dataSource.NAME.discardIdleConnectionsSeconds = 60`

**Work Around**

The current work around is to use the undocumented javabean field: `org.quartz.dataSource.NAME.maxIdleTime = 60`