### PR TITLE
Issue #9: actually fixed the Java 8 javadoc issue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,8 @@
     <skipDeploy>false</skipDeploy>
     <skipJavadoc>false</skipJavadoc>
     <skipCheckstyle>false</skipCheckstyle>
-
+    <additionalparam>-Xdoclint:none</additionalparam>
+    
     <slf4j.version>1.7.7</slf4j.version>
     <c3p0.version>0.9.1.1</c3p0.version>
     <log4j.version>1.2.16</log4j.version>


### PR DESCRIPTION
The 'doclint:none' parameter must be included on the root pom.xml for
this to work properly.