### PR TITLE
Add *.ser to ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Maven and test related noise
 target/
 derby.log
+*.ser
 
 # IntelliJ IDEA noise
 out/


### PR DESCRIPTION
After tests run, we get many *.ser files sitting in quartz directory. These needs to be excluded.