### PR TITLE
Fix maven package (javadoc -Xdoclint:none) failed with JDK6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
     <skipDeploy>false</skipDeploy>
     <skipJavadoc>false</skipJavadoc>
     <skipCheckstyle>false</skipCheckstyle>
-    <additionalparam>-Xdoclint:none</additionalparam>
     
     <slf4j.version>1.7.7</slf4j.version>
     <c3p0.version>0.9.1.1</c3p0.version>
@@ -349,7 +348,16 @@
       <modules>
         <module>system-tests</module>
       </modules>
-    </profile>    
+    </profile>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
+    </profile>
   </profiles>  
 
   <distributionManagement>


### PR DESCRIPTION
It looks like the PR#50 work of adding -Xdoclint:none only works for JDK8, but not
JDK7 nor JDK6! We need to create a separate profile that detect JDK version for
these flags.

Issue#63