### PR TITLE
Make Quartz JDK7 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Maven and test related noise
 target/
 derby.log
-*.ser
 
 # IntelliJ IDEA noise
 out/

--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -2,10 +2,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.quartz-scheduler</groupId>
+    <artifactId>quartz-parent</artifactId>
+    <version>2.3.0-SNAPSHOT</version>
+  </parent>
+
   <groupId>org.quartz-scheduler.internal</groupId>
   <artifactId>quartz-checkstyle</artifactId>
   <name>quartz-checkstyle</name>
-  <version>2.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/distribution/examples/pom.xml
+++ b/distribution/examples/pom.xml
@@ -6,8 +6,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>quartz-examples</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>quartz-kit</artifactId>

--- a/management-quartz-impl/pom.xml
+++ b/management-quartz-impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>management-quartz-impl</artifactId>

--- a/management-quartz/pom.xml
+++ b/management-quartz/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>management-quartz</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,9 @@
   </modules>
 
   <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <skipDeploy>false</skipDeploy>
     <skipJavadoc>false</skipJavadoc>
@@ -185,9 +188,7 @@
           <configuration>
             <fork>true</fork>
             <meminitial>128</meminitial>
-            <maxmem>512</maxmem>            
-            <source>1.6</source>
-            <target>1.6</target>
+            <maxmem>512</maxmem>
           </configuration>
         </plugin>      
         <plugin>

--- a/system-tests/pom.xml
+++ b/system-tests/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>org.quartz-scheduler.internal</groupId>
   <artifactId>quartz-terracotta-system-tests</artifactId>
-  <version>2.2.4-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <name>quartz-terracotta-system-tests</name>
 
   <properties>


### PR DESCRIPTION
We should target JDK7 starting quartz-2.3.x which is the current master branch.
