### PR TITLE
Remove unused mvnsearch repository from pom

### DIFF
--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.quartz-scheduler</groupId>
+    <artifactId>quartz-parent</artifactId>
+    <version>2.3.0-SNAPSHOT</version>
+  </parent>
+
   <groupId>org.quartz-scheduler.internal</groupId>
   <artifactId>quartz-checkstyle</artifactId>
   <name>quartz-checkstyle</name>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
+
     <skipDeploy>false</skipDeploy>
     <skipJavadoc>false</skipJavadoc>
     <skipCheckstyle>false</skipCheckstyle>
@@ -185,9 +188,7 @@
           <configuration>
             <fork>true</fork>
             <meminitial>128</meminitial>
-            <maxmem>512</maxmem>            
-            <source>1.6</source>
-            <target>1.6</target>
+            <maxmem>512</maxmem>
           </configuration>
         </plugin>      
         <plugin>

--- a/quartz-oracle/pom.xml
+++ b/quartz-oracle/pom.xml
@@ -25,13 +25,6 @@
       <scope>provided</scope>
     </dependency>    
   </dependencies>
-  
-  <repositories>
-    <repository>
-      <id>mvnsearch</id>
-      <url>http://www.mvnsearch.org/maven2/</url>
-    </repository>
-  </repositories>
 
   <profiles>
     <profile>


### PR DESCRIPTION
- Set Java compiler source to 1.6 using system property instead of plugin configuration.
  This makes other maven plugins aware of the 1.6 settings besides just the compiler. More
  portable and consistent this way.

Issue#77
