### PR TITLE
Avoid of a classloader memory leak on redeploy of web applications

### DIFF
--- a/quartz-plugins/pom.xml
+++ b/quartz-plugins/pom.xml
@@ -58,7 +58,13 @@
       <artifactId>junit-dep</artifactId>
       <version>4.8.2</version>
       <scope>test</scope>
-    </dependency>    
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.2.12</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>asm</groupId>
       <artifactId>asm</artifactId>

--- a/quartz-plugins/src/main/java/org/quartz/plugins/management/ShutdownHookPlugin.java
+++ b/quartz-plugins/src/main/java/org/quartz/plugins/management/ShutdownHookPlugin.java
@@ -45,6 +45,7 @@ public class ShutdownHookPlugin implements SchedulerPlugin {
     private boolean cleanShutdown = true;
 
     private final Logger log = LoggerFactory.getLogger(getClass());
+    private Thread thread;
     
     /*
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -111,7 +112,7 @@ public class ShutdownHookPlugin implements SchedulerPlugin {
      * the <code>SchedulerPlugin</code> a chance to initialize.
      * </p>
      * 
-     * @throws SchedulerConfigException
+     * @throws SchedulerException
      *           if there is an error initializing.
      */
     public void initialize(String name, final Scheduler scheduler, ClassLoadHelper classLoadHelper)
@@ -119,7 +120,7 @@ public class ShutdownHookPlugin implements SchedulerPlugin {
 
         getLog().info("Registering Quartz shutdown hook.");
 
-        Thread t = new Thread("Quartz Shutdown-Hook "
+        thread = new Thread("Quartz Shutdown-Hook "
                 + scheduler.getSchedulerName()) {
             @Override
             public void run() {
@@ -133,7 +134,7 @@ public class ShutdownHookPlugin implements SchedulerPlugin {
             }
         };
 
-        Runtime.getRuntime().addShutdownHook(t);
+        Runtime.getRuntime().addShutdownHook(thread);
     }
 
     public void start() {
@@ -148,8 +149,8 @@ public class ShutdownHookPlugin implements SchedulerPlugin {
      * </p>
      */
     public void shutdown() {
-        // nothing to do in this case (since the scheduler is already shutting
-        // down)
+        // remove new thread from runtime hooks
+        Runtime.getRuntime().removeShutdownHook(thread);
     }
 
 }

--- a/quartz-plugins/src/test/java/org/quartz/plugins/management/ShutdownHookPluginTest.java
+++ b/quartz-plugins/src/test/java/org/quartz/plugins/management/ShutdownHookPluginTest.java
@@ -1,0 +1,48 @@
+package org.quartz.plugins.management;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.quartz.Scheduler;
+import org.quartz.core.QuartzScheduler;
+import org.quartz.impl.StdScheduler;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for classloader memory leak in the plugin
+ */
+public class ShutdownHookPluginTest {
+
+    @Test
+    public void testInitialize() throws Exception {
+        Scheduler scheduler = mock(Scheduler.class);
+        when(scheduler.getSchedulerName()).thenReturn("Mock-Scheduler");
+
+        ShutdownHookPlugin plugin = new ShutdownHookPlugin();
+        plugin.initialize("TestName", scheduler, null);
+
+        assertEquals(getShutdownHookCount(), 1);
+
+        plugin.shutdown();
+
+        assertEquals("After plugin shutdown the hook should not be present", getShutdownHookCount(), 0);
+    }
+
+    private int getShutdownHookCount() {
+        try {
+            Class clazz = Class.forName("java.lang.ApplicationShutdownHooks");
+            Field field = clazz.getDeclaredField("hooks");
+            field.setAccessible(true);
+            Map<Thread, Thread> hooks = (Map<Thread, Thread>) field.get(null);
+
+            return hooks.entrySet().size();
+        } catch (Exception e) {
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
I've figured out when using quartz scheduler on web applications and using redeploy of your application, a classloader memory leak appears. The cause in details:
1. Create schedulers, the plugin registers `new Thread` in runtime shutdown hooks.
2. When you shut down your server, it's OK, JVM finishes, and there is no any problem.
3. BUT if you redeploy your application, ... bla-bla-bla, you create schedulers again, and they register **another** `new Thread` in runtime shutdown hooks. JVM runtime shutdown hook collection is a GC-root. It holds your new Thread and it's classloader (WebAppClassLoader on Tomcat) with all consequences.
4. Every time you redeploy your application, you don't unload your WebAppClassLoader with thousands of loaded classes and this can cause a permgen memory leak.
The issue is actual in all versions of the plugin.
I've fixed it with a pretty simple code and added a test to check it. Also added Mockito dependency (you can drop it if you don't need). 