### PR TITLE
word mixup in docu: name instead of group

### DIFF
--- a/quartz-core/src/main/java/org/quartz/JobKey.java
+++ b/quartz-core/src/main/java/org/quartz/JobKey.java
@@ -23,7 +23,7 @@ import org.quartz.utils.Key;
  * Uniquely identifies a {@link JobDetail}.
  * 
  * <p>Keys are composed of both a name and group, and the name must be unique
- * within the group.  If only a group is specified then the default group
+ * within the group.  If only a name is specified then the default group
  * name will be used.</p> 
  *
  * <p>Quartz provides a builder-style API for constructing scheduling-related


### PR DESCRIPTION
"If only a group is specified then the default group"
It was probably meant to be
"If only a name is specified then the default group"

This makes sense