### PR TITLE
Delay reading from job store on repeated errors

### DIFF
--- a/quartz-core/src/main/java/org/quartz/core/QuartzSchedulerThread.java
+++ b/quartz-core/src/main/java/org/quartz/core/QuartzSchedulerThread.java
@@ -27,8 +27,6 @@ import org.quartz.JobPersistenceException;
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
 import org.quartz.Trigger.CompletedExecutionInstruction;
-import org.quartz.impl.jdbcjobstore.JobStoreSupport;
-import org.quartz.spi.JobStore;
 import org.quartz.spi.OperableTrigger;
 import org.quartz.spi.TriggerFiredBundle;
 import org.quartz.spi.TriggerFiredResult;
@@ -269,7 +267,7 @@ public class QuartzSchedulerThread extends Thread {
                 // wait a bit, if reading from job store is consistently
                 // failing (e.g. DB is down or restarting)..
                 if (acquiresFailed > 1) {
-                    long delay = computeDelayForRepeatedErrors(qsRsrcs.getJobStore(), acquiresFailed);
+                    long delay = computeDelayForRepeatedErrors(acquiresFailed);
                     try {
                         Thread.sleep(delay);
                     } catch (InterruptedException ignore) {
@@ -440,19 +438,13 @@ public class QuartzSchedulerThread extends Thread {
         qsRsrcs = null;
     }
 
-    private static long computeDelayForRepeatedErrors(JobStore jobStore, long acquiresFailed) {
-        long interval;
+    private static long computeDelayForRepeatedErrors(long acquiresFailed) {
+        assert acquiresFailed > 0;
 
-        if (jobStore instanceof JobStoreSupport) {
-            interval = ((JobStoreSupport)jobStore).getDbRetryInterval();
-        } else {
-            interval = 250 * acquiresFailed;
-        }
+        long interval = 250 * acquiresFailed;
 
         if (interval > 5000)
             interval = 5000;
-        if (interval < 50)
-            interval = 50;
 
         return interval;
     }

--- a/quartz-core/src/main/java/org/quartz/core/QuartzSchedulerThread.java
+++ b/quartz-core/src/main/java/org/quartz/core/QuartzSchedulerThread.java
@@ -27,6 +27,8 @@ import org.quartz.JobPersistenceException;
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
 import org.quartz.Trigger.CompletedExecutionInstruction;
+import org.quartz.impl.jdbcjobstore.JobStoreSupport;
+import org.quartz.spi.JobStore;
 import org.quartz.spi.OperableTrigger;
 import org.quartz.spi.TriggerFiredBundle;
 import org.quartz.spi.TriggerFiredResult;
@@ -241,7 +243,7 @@ public class QuartzSchedulerThread extends Thread {
      */
     @Override
     public void run() {
-        boolean lastAcquireFailed = false;
+        long acquiresFailed = 0;
 
         while (!halted.get()) {
             try {
@@ -253,6 +255,10 @@ public class QuartzSchedulerThread extends Thread {
                             sigLock.wait(1000L);
                         } catch (InterruptedException ignore) {
                         }
+
+                        // reset failure counter when paused, so that we don't
+                        // wait again after unpausing
+                        acquiresFailed = 0;
                     }
 
                     if (halted.get()) {
@@ -260,10 +266,20 @@ public class QuartzSchedulerThread extends Thread {
                     }
                 }
 
+                // wait a bit, if reading from job store is consistently
+                // failing (e.g. DB is down or restarting)..
+                if (acquiresFailed > 1) {
+                    long delay = computeDelayForRepeatedErrors(qsRsrcs.getJobStore(), acquiresFailed);
+                    try {
+                        Thread.sleep(delay);
+                    } catch (InterruptedException ignore) {
+                    }
+                }
+
                 int availThreadCount = qsRsrcs.getThreadPool().blockForAvailableThreads();
                 if(availThreadCount > 0) { // will always be true, due to semantics of blockForAvailableThreads...
 
-                    List<OperableTrigger> triggers = null;
+                    List<OperableTrigger> triggers;
 
                     long now = System.currentTimeMillis();
 
@@ -271,23 +287,23 @@ public class QuartzSchedulerThread extends Thread {
                     try {
                         triggers = qsRsrcs.getJobStore().acquireNextTriggers(
                                 now + idleWaitTime, Math.min(availThreadCount, qsRsrcs.getMaxBatchSize()), qsRsrcs.getBatchTimeWindow());
-                        lastAcquireFailed = false;
-                        if (log.isDebugEnabled()) 
+                        acquiresFailed = 0;
+                        if (log.isDebugEnabled())
                             log.debug("batch acquisition of " + (triggers == null ? 0 : triggers.size()) + " triggers");
                     } catch (JobPersistenceException jpe) {
-                        if(!lastAcquireFailed) {
+                        if (acquiresFailed == 0) {
                             qs.notifySchedulerListenersError(
                                 "An error occurred while scanning for the next triggers to fire.",
                                 jpe);
                         }
-                        lastAcquireFailed = true;
+                        acquiresFailed++;
                         continue;
                     } catch (RuntimeException e) {
-                        if(!lastAcquireFailed) {
+                        if (acquiresFailed == 0) {
                             getLog().error("quartzSchedulerThreadLoop: RuntimeException "
                                     +e.getMessage(), e);
                         }
-                        lastAcquireFailed = true;
+                        acquiresFailed++;
                         continue;
                     }
 
@@ -422,6 +438,23 @@ public class QuartzSchedulerThread extends Thread {
         // drop references to scheduler stuff to aid garbage collection...
         qs = null;
         qsRsrcs = null;
+    }
+
+    private static long computeDelayForRepeatedErrors(JobStore jobStore, long acquiresFailed) {
+        long interval;
+
+        if (jobStore instanceof JobStoreSupport) {
+            interval = ((JobStoreSupport)jobStore).getDbRetryInterval();
+        } else {
+            interval = 250 * acquiresFailed;
+        }
+
+        if (interval > 5000)
+            interval = 5000;
+        if (interval < 50)
+            interval = 50;
+
+        return interval;
     }
 
     private boolean releaseIfScheduleChangedSignificantly(

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -616,7 +616,12 @@ public abstract class JobStoreSupport implements JobStore, Constants {
             boolean doubleCheckLockMisfireHandler) {
         this.doubleCheckLockMisfireHandler = doubleCheckLockMisfireHandler;
     }
-    
+
+    @Override
+    public long getAcquireRetryDelay(int failureCount) {
+        return dbRetryInterval;
+    }
+
     //---------------------------------------------------------------------------
     // interface methods
     //---------------------------------------------------------------------------

--- a/quartz-core/src/main/java/org/quartz/simpl/RAMJobStore.java
+++ b/quartz-core/src/main/java/org/quartz/simpl/RAMJobStore.java
@@ -1650,6 +1650,11 @@ public class RAMJobStore implements JobStore {
         }
     }
 
+    @Override
+    public long getAcquireRetryDelay(int failureCount) {
+        return 20;
+    }
+
     protected void setAllTriggersOfJobToState(JobKey jobKey, int state) {
         ArrayList<TriggerWrapper> tws = getTriggerWrappersForJob(jobKey);
         for (TriggerWrapper tw : tws) {

--- a/quartz-core/src/main/java/org/quartz/spi/JobStore.java
+++ b/quartz-core/src/main/java/org/quartz/spi/JobStore.java
@@ -632,4 +632,22 @@ public interface JobStore {
      * @since 2.0
      */
     void setThreadPoolSize(int poolSize);
+
+    /**
+     * Get the amount of time (in ms) to wait when accessing this job store
+     * repeatedly fails.
+     *
+     * Called by the executor thread(s) when calls to
+     * {@link #acquireNextTriggers} fail more than once in succession, and the
+     * thread thus wants to wait a bit before trying again, to not consume
+     * 100% CPU, write huge amounts of errors into logs, etc. in cases like
+     * the DB being offline/restarting.
+     *
+     * The delay returned by implementations should be between 20 and
+     * 600000 milliseconds.
+     *
+     * @param failureCount the number of successive failures seen so far
+     * @return the time (in milliseconds) to wait before trying again
+     */
+    long getAcquireRetryDelay(int failureCount);
 }

--- a/terracotta/bootstrap/src/main/java/org/terracotta/quartz/AbstractTerracottaJobStore.java
+++ b/terracotta/bootstrap/src/main/java/org/terracotta/quartz/AbstractTerracottaJobStore.java
@@ -598,6 +598,15 @@ public abstract class AbstractTerracottaJobStore implements JobStore {
     }
   }
 
+  @Override
+  public long getAcquireRetryDelay(int failureCount) {
+    try {
+      return realJobStore.getAcquireRetryDelay(failureCount);
+    } catch (Exception e) {
+      return 20;
+    }
+  }
+
   protected TerracottaJobStoreExtensions getRealJobStore() {
     return realJobStore;
   }

--- a/terracotta/bootstrap/src/main/java/org/terracotta/quartz/DefaultClusteredJobStore.java
+++ b/terracotta/bootstrap/src/main/java/org/terracotta/quartz/DefaultClusteredJobStore.java
@@ -2006,6 +2006,11 @@ class DefaultClusteredJobStore implements ClusteredJobStore {
     throw new AssertionError();
   }
 
+  @Override
+  public long getAcquireRetryDelay(int failureCount) {
+    return retryInterval;
+  }
+
   void injectTriggerWrapper(final TriggerWrapper triggerWrapper) {
     timeTriggers.add(triggerWrapper);
   }

--- a/terracotta/bootstrap/src/main/java/org/terracotta/quartz/PlainTerracottaJobStore.java
+++ b/terracotta/bootstrap/src/main/java/org/terracotta/quartz/PlainTerracottaJobStore.java
@@ -379,6 +379,11 @@ public class PlainTerracottaJobStore<T extends ClusteredJobStore> implements Ter
   }
 
   @Override
+  public long getAcquireRetryDelay(int failureCount) {
+    return tcRetryInterval;
+  }
+
+  @Override
   public String getUUID() {
     return toolkit.getClientUUID();
   }


### PR DESCRIPTION
Hello,
this change helps with issue https://github.com/quartz-scheduler/quartz/issues/71, which is occasionally causing us some trouble in production.

If it's acceptable, it'd be great if we could also get it backported to the 2.2.x series, so that we don't have to wait until 2.3 is finished.. I don't know how that is done, though..

If it's not acceptable, please let me know of a better approach and I'm happy to change the implementation..