### PR TITLE
Add support for hikari cp, upgrade c3p0 library, break static dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,8 @@
     <skipCheckstyle>false</skipCheckstyle>
     
     <slf4j.version>1.7.7</slf4j.version>
-    <c3p0.version>0.9.1.1</c3p0.version>
+    <c3p0.version>0.9.5.2</c3p0.version>
+    <hikaricp.version>2.3.13</hikaricp.version>
     <log4j.version>1.2.16</log4j.version>
     <maven-forge-plugin.version>1.1.9</maven-forge-plugin.version>
     <gmaven-plugin.version>1.4</gmaven-plugin.version>

--- a/quartz-core/pom.xml
+++ b/quartz-core/pom.xml
@@ -19,9 +19,15 @@
   <dependencies>
     <!--Compile scope. If you add something to compile scope, you have to do the same thing in packaging/pom.xml -->
     <dependency>
-      <groupId>c3p0</groupId>
+      <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
       <version>${c3p0.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP-java6</artifactId>
+      <version>${hikaricp.version}</version>
     </dependency>
 
     <dependency>

--- a/quartz-core/src/main/java/org/quartz/utils/C3p0PoolingConnectionProvider.java
+++ b/quartz-core/src/main/java/org/quartz/utils/C3p0PoolingConnectionProvider.java
@@ -1,0 +1,233 @@
+/* 
+ * Copyright Terracotta, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+ * use this file except in compliance with the License. You may obtain a copy 
+ * of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+ * License for the specific language governing permissions and limitations 
+ * under the License.
+ * 
+ */
+
+package org.quartz.utils;
+
+import java.beans.PropertyVetoException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.quartz.SchedulerException;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+
+/**
+ * <p>
+ * A <code>ConnectionProvider</code> implementation that creates its own
+ * pool of connections.
+ * </p>
+ *
+ * <p>
+ * This class uses C3PO (http://www.mchange.com/projects/c3p0/index.html) as
+ * the underlying pool implementation.</p>
+ *
+ * @see DBConnectionManager
+ * @see ConnectionProvider
+ *
+ * @author Sharada Jambula
+ * @author James House
+ * @author Mohammad Rezaei
+ */
+public class C3p0PoolingConnectionProvider implements PoolingConnectionProvider {
+
+    /*
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * 
+     * Constants.
+     * 
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     */
+
+    /**
+     * The maximum number of prepared statements that will be cached per connection in the pool.
+     * Depending upon your JDBC Driver this may significantly help performance, or may slightly 
+     * hinder performance.   
+     * Default is 120, as Quartz uses over 100 unique statements. 0 disables the feature. 
+     */
+    public static final String DB_MAX_CACHED_STATEMENTS_PER_CONNECTION = "maxCachedStatementsPerConnection";
+
+    /**
+     * The number of seconds between tests of idle connections - only enabled
+     * if the validation query property is set.  Default is 50 seconds. 
+     */
+    public static final String DB_IDLE_VALIDATION_SECONDS = "idleConnectionValidationSeconds";
+
+    /**
+     * Whether the database sql query to validate connections should be executed every time 
+     * a connection is retrieved from the pool to ensure that it is still valid.  If false,
+     * then validation will occur on check-in.  Default is false. 
+     */
+    public static final String DB_VALIDATE_ON_CHECKOUT = "validateOnCheckout";
+
+    /** Discard connections after they have been idle this many seconds.  0 disables the feature. Default is 0.*/
+    private static final String DB_DISCARD_IDLE_CONNECTIONS_SECONDS = "maxIdleTime";
+
+    /** Default maximum number of database connections in the pool. */
+    public static final int DEFAULT_DB_MAX_CACHED_STATEMENTS_PER_CONNECTION = 120;
+
+
+    /*
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * 
+     * Data members.
+     * 
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     */
+
+    private ComboPooledDataSource datasource;
+
+    /*
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * 
+     * Constructors.
+     * 
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     */
+
+    public C3p0PoolingConnectionProvider(String dbDriver, String dbURL,
+                                         String dbUser, String dbPassword, int maxConnections,
+                                         String dbValidationQuery) throws SQLException, SchedulerException {
+        initialize(
+                dbDriver, dbURL, dbUser, dbPassword,
+                maxConnections, DEFAULT_DB_MAX_CACHED_STATEMENTS_PER_CONNECTION, dbValidationQuery, false, 50, 0);
+    }
+
+    /**
+     * Create a connection pool using the given properties.
+     *
+     * <p>
+     * The properties passed should contain:
+     * <UL>
+     * <LI>{@link #DB_DRIVER}- The database driver class name
+     * <LI>{@link #DB_URL}- The database URL
+     * <LI>{@link #DB_USER}- The database user
+     * <LI>{@link #DB_PASSWORD}- The database password
+     * <LI>{@link #DB_MAX_CONNECTIONS}- The maximum # connections in the pool,
+     * optional
+     * <LI>{@link #DB_VALIDATION_QUERY}- The sql validation query, optional
+     * </UL>
+     * </p>
+     *
+     * @param config
+     *            configuration properties
+     */
+    public C3p0PoolingConnectionProvider(Properties config) throws SchedulerException, SQLException {
+        PropertiesParser cfg = new PropertiesParser(config);
+        initialize(
+                cfg.getStringProperty(DB_DRIVER),
+                cfg.getStringProperty(DB_URL),
+                cfg.getStringProperty(DB_USER, ""),
+                cfg.getStringProperty(DB_PASSWORD, ""),
+                cfg.getIntProperty(DB_MAX_CONNECTIONS, DEFAULT_DB_MAX_CONNECTIONS),
+                cfg.getIntProperty(DB_MAX_CACHED_STATEMENTS_PER_CONNECTION, DEFAULT_DB_MAX_CACHED_STATEMENTS_PER_CONNECTION),
+                cfg.getStringProperty(DB_VALIDATION_QUERY),
+                cfg.getBooleanProperty(DB_VALIDATE_ON_CHECKOUT, false),
+                cfg.getIntProperty(DB_IDLE_VALIDATION_SECONDS, 50),
+                cfg.getIntProperty(DB_DISCARD_IDLE_CONNECTIONS_SECONDS, 0));
+    }
+    
+    /*
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * 
+     * Interface.
+     * 
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     */
+
+    /**
+     * Create the underlying C3PO ComboPooledDataSource with the 
+     * default supported properties.
+     * @throws SchedulerException
+     */
+    private void initialize(
+            String dbDriver,
+            String dbURL,
+            String dbUser,
+            String dbPassword,
+            int maxConnections,
+            int maxStatementsPerConnection,
+            String dbValidationQuery,
+            boolean validateOnCheckout,
+            int idleValidationSeconds,
+            int maxIdleSeconds) throws SQLException, SchedulerException {
+        if (dbURL == null) {
+            throw new SQLException(
+                    "DBPool could not be created: DB URL cannot be null");
+        }
+
+        if (dbDriver == null) {
+            throw new SQLException(
+                    "DBPool '" + dbURL + "' could not be created: " +
+                            "DB driver class name cannot be null!");
+        }
+
+        if (maxConnections < 0) {
+            throw new SQLException(
+                    "DBPool '" + dbURL + "' could not be created: " +
+                            "Max connections must be greater than zero!");
+        }
+
+
+        datasource = new ComboPooledDataSource();
+        try {
+            datasource.setDriverClass(dbDriver);
+        } catch (PropertyVetoException e) {
+            throw new SchedulerException("Problem setting driver class name on datasource: " + e.getMessage(), e);
+        }
+        datasource.setJdbcUrl(dbURL);
+        datasource.setUser(dbUser);
+        datasource.setPassword(dbPassword);
+        datasource.setMaxPoolSize(maxConnections);
+        datasource.setMinPoolSize(1);
+        datasource.setMaxIdleTime(maxIdleSeconds);
+        datasource.setMaxStatementsPerConnection(maxStatementsPerConnection);
+
+        if (dbValidationQuery != null) {
+            datasource.setPreferredTestQuery(dbValidationQuery);
+            if(!validateOnCheckout)
+                datasource.setTestConnectionOnCheckin(true);
+            else
+                datasource.setTestConnectionOnCheckout(true);
+            datasource.setIdleConnectionTestPeriod(idleValidationSeconds);
+        }
+    }
+
+    /**
+     * Get the C3PO ComboPooledDataSource created during initialization.
+     *
+     * <p>
+     * This can be used to set additional data source properties in a 
+     * subclass's constructor.
+     * </p>
+     */
+    public ComboPooledDataSource getDataSource() {
+        return datasource;
+    }
+
+    public Connection getConnection() throws SQLException {
+        return datasource.getConnection();
+    }
+
+    public void shutdown() throws SQLException {
+        datasource.close();
+    }
+
+    public void initialize() throws SQLException {
+        // do nothing, already initialized during constructor call
+    }
+}

--- a/quartz-core/src/main/java/org/quartz/utils/HikariCpPoolingConnectionProvider.java
+++ b/quartz-core/src/main/java/org/quartz/utils/HikariCpPoolingConnectionProvider.java
@@ -1,0 +1,190 @@
+/* 
+ * Copyright Terracotta, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+ * use this file except in compliance with the License. You may obtain a copy 
+ * of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+ * License for the specific language governing permissions and limitations 
+ * under the License.
+ * 
+ */
+
+package org.quartz.utils;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.quartz.SchedulerException;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ * <p>
+ * A <code>ConnectionProvider</code> implementation that creates its own
+ * pool of connections.
+ * </p>
+ *
+ * <p>
+ * This class uses HikariCP (https://brettwooldridge.github.io/HikariCP/) as
+ * the underlying pool implementation.</p>
+ *
+ * @see DBConnectionManager
+ * @see ConnectionProvider
+ *
+ * @author Ludovic Orban
+ */
+public class HikariCpPoolingConnectionProvider implements PoolingConnectionProvider {
+
+    /*
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     *
+     * Constants.
+     *
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     */
+
+    /** This pooling provider name. */
+    public static final String POOLING_PROVIDER_NAME = "hikaricp";
+
+    /** Discard connections after they have been idle this many seconds.  0 disables the feature. Default is 0.*/
+    private static final String DB_DISCARD_IDLE_CONNECTIONS_SECONDS = "discardIdleConnectionsSeconds";
+
+    /*
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     *
+     * Data members.
+     *
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     */
+
+    private HikariDataSource datasource;
+
+    /*
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     *
+     * Constructors.
+     *
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     */
+
+    public HikariCpPoolingConnectionProvider(String dbDriver, String dbURL,
+                                             String dbUser, String dbPassword, int maxConnections,
+                                             String dbValidationQuery) throws SQLException, SchedulerException {
+        initialize(
+                dbDriver, dbURL, dbUser, dbPassword,
+                maxConnections, dbValidationQuery, 0);
+    }
+
+    /**
+     * Create a connection pool using the given properties.
+     *
+     * <p>
+     * The properties passed should contain:
+     * <UL>
+     * <LI>{@link #DB_DRIVER}- The database driver class name
+     * <LI>{@link #DB_URL}- The database URL
+     * <LI>{@link #DB_USER}- The database user
+     * <LI>{@link #DB_PASSWORD}- The database password
+     * <LI>{@link #DB_MAX_CONNECTIONS}- The maximum # connections in the pool,
+     * optional
+     * <LI>{@link #DB_VALIDATION_QUERY}- The sql validation query, optional
+     * </UL>
+     * </p>
+     *
+     * @param config
+     *            configuration properties
+     */
+    public HikariCpPoolingConnectionProvider(Properties config) throws SchedulerException, SQLException {
+        PropertiesParser cfg = new PropertiesParser(config);
+        initialize(
+                cfg.getStringProperty(DB_DRIVER),
+                cfg.getStringProperty(DB_URL),
+                cfg.getStringProperty(DB_USER, ""),
+                cfg.getStringProperty(DB_PASSWORD, ""),
+                cfg.getIntProperty(DB_MAX_CONNECTIONS, DEFAULT_DB_MAX_CONNECTIONS),
+                cfg.getStringProperty(DB_VALIDATION_QUERY),
+                cfg.getIntProperty(DB_DISCARD_IDLE_CONNECTIONS_SECONDS, 0));
+    }
+    
+    /*
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * 
+     * Interface.
+     * 
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     */
+
+    /**
+     * Create the underlying C3PO ComboPooledDataSource with the 
+     * default supported properties.
+     * @throws SchedulerException
+     */
+    private void initialize(
+            String dbDriver,
+            String dbURL,
+            String dbUser,
+            String dbPassword,
+            int maxConnections,
+            String dbValidationQuery,
+            int maxIdleSeconds) throws SQLException, SchedulerException {
+        if (dbURL == null) {
+            throw new SQLException(
+                    "DBPool could not be created: DB URL cannot be null");
+        }
+
+        if (dbDriver == null) {
+            throw new SQLException(
+                    "DBPool '" + dbURL + "' could not be created: " +
+                            "DB driver class name cannot be null!");
+        }
+
+        if (maxConnections < 0) {
+            throw new SQLException(
+                    "DBPool '" + dbURL + "' could not be created: " +
+                            "Max connections must be greater than zero!");
+        }
+
+
+        datasource = new HikariDataSource();
+        datasource.setDriverClassName(dbDriver);
+        datasource.setJdbcUrl(dbURL);
+        datasource.setUsername(dbUser);
+        datasource.setPassword(dbPassword);
+        datasource.setMaximumPoolSize(maxConnections);
+        datasource.setIdleTimeout(maxIdleSeconds);
+
+        if (dbValidationQuery != null) {
+            datasource.setConnectionTestQuery(dbValidationQuery);
+        }
+    }
+
+    /**
+     * Get the HikariCP HikariDataSource created during initialization.
+     *
+     * <p>
+     * This can be used to set additional data source properties in a 
+     * subclass's constructor.
+     * </p>
+     */
+    public HikariDataSource getDataSource() {
+        return datasource;
+    }
+
+    public Connection getConnection() throws SQLException {
+        return datasource.getConnection();
+    }
+
+    public void shutdown() throws SQLException {
+        datasource.close();
+    }
+
+    public void initialize() throws SQLException {
+        // do nothing, already initialized during constructor call
+    }
+}

--- a/quartz-core/src/main/java/org/quartz/utils/PoolingConnectionProvider.java
+++ b/quartz-core/src/main/java/org/quartz/utils/PoolingConnectionProvider.java
@@ -1,257 +1,73 @@
-/* 
- * Copyright 2001-2009 Terracotta, Inc. 
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not 
- * use this file except in compliance with the License. You may obtain a copy 
- * of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- *   
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
- * 
+ *
  */
 
 package org.quartz.utils;
 
-import java.beans.PropertyVetoException;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Properties;
-
-import org.quartz.SchedulerException;
-
-import com.mchange.v2.c3p0.ComboPooledDataSource;
+import javax.sql.DataSource;
 
 /**
  * <p>
- * A <code>ConnectionProvider</code> implementation that creates its own
- * pool of connections.
+ * <code>ConnectionProvider</code>s supporting pooling of connections.
  * </p>
- * 
+ *
  * <p>
- * This class uses C3PO (http://www.mchange.com/projects/c3p0/index.html) as
- * the underlying pool implementation.</p>
- * 
+ * Implementations must pool connections.
+ * </p>
+ *
  * @see DBConnectionManager
  * @see ConnectionProvider
- * 
- * @author Sharada Jambula
- * @author James House
- * @author Mohammad Rezaei
+ * @author Ludovic Orban
  */
-public class PoolingConnectionProvider implements ConnectionProvider {
+public interface PoolingConnectionProvider extends ConnectionProvider {
 
-    /*
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     * 
-     * Constants.
-     * 
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     */
+    /** The pooling provider. */
+    String POOLING_PROVIDER = "provider";
+
+    /** The c3p0 pooling provider. */
+    String POOLING_PROVIDER_C3P0 = "c3p0";
+
+    /** The Hikari pooling provider. */
+    String POOLING_PROVIDER_HIKARICP = "hikaricp";
 
     /** The JDBC database driver. */
-    public static final String DB_DRIVER = "driver";
+    String DB_DRIVER = "driver";
 
     /** The JDBC database URL. */
-    public static final String DB_URL = "URL";
+    String DB_URL = "URL";
 
     /** The database user name. */
-    public static final String DB_USER = "user";
+    String DB_USER = "user";
 
     /** The database user password. */
-    public static final String DB_PASSWORD = "password";
+    String DB_PASSWORD = "password";
 
     /** The maximum number of database connections to have in the pool.  Default is 10. */
-    public static final String DB_MAX_CONNECTIONS = "maxConnections";
+    String DB_MAX_CONNECTIONS = "maxConnections";
 
-    /** 
-     * The maximum number of prepared statements that will be cached per connection in the pool.
-     * Depending upon your JDBC Driver this may significantly help performance, or may slightly 
-     * hinder performance.   
-     * Default is 120, as Quartz uses over 100 unique statements. 0 disables the feature. 
+    /**
+     * The database sql query to execute every time a connection is returned
+     * to the pool to ensure that it is still valid.
      */
-    public static final String DB_MAX_CACHED_STATEMENTS_PER_CONNECTION = "maxCachedStatementsPerConnection";
-
-    /** 
-     * The database sql query to execute every time a connection is returned 
-     * to the pool to ensure that it is still valid. 
-     */
-    public static final String DB_VALIDATION_QUERY = "validationQuery";
-
-    /** 
-     * The number of seconds between tests of idle connections - only enabled
-     * if the validation query property is set.  Default is 50 seconds. 
-     */
-    public static final String DB_IDLE_VALIDATION_SECONDS = "idleConnectionValidationSeconds";
-
-    /** 
-     * Whether the database sql query to validate connections should be executed every time 
-     * a connection is retrieved from the pool to ensure that it is still valid.  If false,
-     * then validation will occur on check-in.  Default is false. 
-     */
-    public static final String DB_VALIDATE_ON_CHECKOUT = "validateOnCheckout";
-    
-    /** Discard connections after they have been idle this many seconds.  0 disables the feature. Default is 0.*/ 
-    public static final String DB_DISCARD_IDLE_CONNECTIONS_SECONDS = "discardIdleConnectionsSeconds";
+    String DB_VALIDATION_QUERY = "validationQuery";
 
     /** Default maximum number of database connections in the pool. */
-    public static final int DEFAULT_DB_MAX_CONNECTIONS = 10;
-
-    /** Default maximum number of database connections in the pool. */
-    public static final int DEFAULT_DB_MAX_CACHED_STATEMENTS_PER_CONNECTION = 120;
+    int DEFAULT_DB_MAX_CONNECTIONS = 10;
 
 
-    /*
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     * 
-     * Data members.
-     * 
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     */
+    DataSource getDataSource();
 
-    private ComboPooledDataSource datasource;
-
-    /*
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     * 
-     * Constructors.
-     * 
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     */
-
-    public PoolingConnectionProvider(String dbDriver, String dbURL,
-            String dbUser, String dbPassword, int maxConnections,
-            String dbValidationQuery) throws SQLException, SchedulerException {
-        initialize(
-            dbDriver, dbURL, dbUser, dbPassword, 
-            maxConnections, DEFAULT_DB_MAX_CACHED_STATEMENTS_PER_CONNECTION, dbValidationQuery, false, 50, 0);
-    }
-
-    /**
-     * Create a connection pool using the given properties.
-     * 
-     * <p>
-     * The properties passed should contain:
-     * <UL>
-     * <LI>{@link #DB_DRIVER}- The database driver class name
-     * <LI>{@link #DB_URL}- The database URL
-     * <LI>{@link #DB_USER}- The database user
-     * <LI>{@link #DB_PASSWORD}- The database password
-     * <LI>{@link #DB_MAX_CONNECTIONS}- The maximum # connections in the pool,
-     * optional
-     * <LI>{@link #DB_VALIDATION_QUERY}- The sql validation query, optional
-     * </UL>
-     * </p>
-     * 
-     * @param config
-     *            configuration properties
-     */
-    public PoolingConnectionProvider(Properties config) throws SchedulerException, SQLException {
-        PropertiesParser cfg = new PropertiesParser(config);
-        initialize(
-            cfg.getStringProperty(DB_DRIVER), 
-            cfg.getStringProperty(DB_URL), 
-            cfg.getStringProperty(DB_USER, ""), 
-            cfg.getStringProperty(DB_PASSWORD, ""), 
-            cfg.getIntProperty(DB_MAX_CONNECTIONS, DEFAULT_DB_MAX_CONNECTIONS), 
-            cfg.getIntProperty(DB_MAX_CACHED_STATEMENTS_PER_CONNECTION, DEFAULT_DB_MAX_CACHED_STATEMENTS_PER_CONNECTION), 
-            cfg.getStringProperty(DB_VALIDATION_QUERY), 
-            cfg.getBooleanProperty(DB_VALIDATE_ON_CHECKOUT, false),
-            cfg.getIntProperty(DB_IDLE_VALIDATION_SECONDS, 50),
-            cfg.getIntProperty(DB_DISCARD_IDLE_CONNECTIONS_SECONDS, 0));
-    }
-    
-    /*
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     * 
-     * Interface.
-     * 
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     */
-    
-    /**
-     * Create the underlying C3PO ComboPooledDataSource with the 
-     * default supported properties.
-     * @throws SchedulerException 
-     */
-    private void initialize(
-        String dbDriver, 
-        String dbURL, 
-        String dbUser,
-        String dbPassword, 
-        int maxConnections, 
-        int maxStatementsPerConnection, 
-        String dbValidationQuery,
-        boolean validateOnCheckout,
-        int idleValidationSeconds,
-        int maxIdleSeconds) throws SQLException, SchedulerException {
-        if (dbURL == null) {
-            throw new SQLException(
-                "DBPool could not be created: DB URL cannot be null");
-        }
-        
-        if (dbDriver == null) {
-            throw new SQLException(
-                "DBPool '" + dbURL + "' could not be created: " +
-                "DB driver class name cannot be null!");
-        }
-        
-        if (maxConnections < 0) {
-            throw new SQLException(
-                "DBPool '" + dbURL + "' could not be created: " + 
-                "Max connections must be greater than zero!");
-        }
-
-        
-        datasource = new ComboPooledDataSource(); 
-        try {
-            datasource.setDriverClass(dbDriver);
-        } catch (PropertyVetoException e) {
-            throw new SchedulerException("Problem setting driver class name on datasource: " + e.getMessage(), e);
-        }  
-        datasource.setJdbcUrl(dbURL); 
-        datasource.setUser(dbUser); 
-        datasource.setPassword(dbPassword);
-        datasource.setMaxPoolSize(maxConnections);
-        datasource.setMinPoolSize(1);
-        datasource.setMaxIdleTime(maxIdleSeconds);
-        datasource.setMaxStatementsPerConnection(maxStatementsPerConnection);
-        
-        if (dbValidationQuery != null) {
-            datasource.setPreferredTestQuery(dbValidationQuery);
-            if(!validateOnCheckout)
-                datasource.setTestConnectionOnCheckin(true);
-            else
-                datasource.setTestConnectionOnCheckout(true);
-            datasource.setIdleConnectionTestPeriod(idleValidationSeconds);
-        }
-    }
-    
-    /**
-     * Get the C3PO ComboPooledDataSource created during initialization.
-     * 
-     * <p>
-     * This can be used to set additional data source properties in a 
-     * subclass's constructor.
-     * </p>
-     */
-    public ComboPooledDataSource getDataSource() {
-        return datasource;
-    }
-
-    public Connection getConnection() throws SQLException {
-        return datasource.getConnection();
-    }
-    
-    public void shutdown() throws SQLException {
-        datasource.close();
-    }    
-
-    public void initialize() throws SQLException {
-        // do nothing, already initialized during constructor call
-    }
 }

--- a/quartz-core/src/test/java/org/quartz/utils/C3p0PoolingConnectionProviderTest.java
+++ b/quartz-core/src/test/java/org/quartz/utils/C3p0PoolingConnectionProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2013 Terracotta, Inc.
+ * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -30,7 +30,7 @@ import java.util.Properties;
 /**
  * A integration test to ensure PoolConnectionProvider is working properly.
  */
-public class PoolingConnectionProviderTest extends QuartzDatabaseTestSupport {
+public class C3p0PoolingConnectionProviderTest extends QuartzDatabaseTestSupport {
     boolean testConnectionProviderClass = false;
 
     @Test
@@ -53,7 +53,7 @@ public class PoolingConnectionProviderTest extends QuartzDatabaseTestSupport {
         DBConnectionManager dbManager = DBConnectionManager.getInstance();
         ConnectionProvider provider = dbManager.getConnectionProvider("myDS");
 
-        ComboPooledDataSource ds = ((PoolingConnectionProvider)provider).getDataSource();
+        ComboPooledDataSource ds = ((C3p0PoolingConnectionProvider)provider).getDataSource();
 
         Assert.assertThat(ds.getDriverClass(), Matchers.is("org.apache.derby.jdbc.ClientDriver"));
         Assert.assertThat(ds.getJdbcUrl(), Matchers.is(JdbcQuartzDerbyUtilities.DATABASE_CONNECTION_PREFIX));
@@ -89,6 +89,8 @@ public class PoolingConnectionProviderTest extends QuartzDatabaseTestSupport {
         if (testConnectionProviderClass)
             properties.put("org.quartz.dataSource.myDS.connectionProvider.class", "org.quartz.utils.PoolingConnectionProvider");
 
+        properties.put("org.quartz.dataSource.myDS.provider", "c3p0");
+
         properties.put("org.quartz.dataSource.myDS.driver", "org.apache.derby.jdbc.ClientDriver");
         properties.put("org.quartz.dataSource.myDS.URL",JdbcQuartzDerbyUtilities.DATABASE_CONNECTION_PREFIX);
         properties.put("org.quartz.dataSource.myDS.user","quartz");
@@ -100,7 +102,7 @@ public class PoolingConnectionProviderTest extends QuartzDatabaseTestSupport {
         properties.put("org.quartz.dataSource.myDS.acquireIncrement","5");
         properties.put("org.quartz.dataSource.myDS.acquireRetryAttempts","3");
         properties.put("org.quartz.dataSource.myDS.acquireRetryDelay","3000");
-        properties.put("org.quartz.dataSource.myDS.discardIdleConnectionsSeconds","60");
+        properties.put("org.quartz.dataSource.myDS.maxIdleTime","60");
 
         return properties;
     }

--- a/quartz-core/src/test/java/org/quartz/utils/HikariCpPoolingConnectionProviderTest.java
+++ b/quartz-core/src/test/java/org/quartz/utils/HikariCpPoolingConnectionProviderTest.java
@@ -1,0 +1,107 @@
+
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.quartz.utils;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.quartz.integrations.tests.JdbcQuartzDerbyUtilities;
+import org.quartz.integrations.tests.QuartzDatabaseTestSupport;
+
+import java.util.Properties;
+
+/**
+ * A integration test to ensure PoolConnectionProvider is working properly.
+ */
+public class HikariCpPoolingConnectionProviderTest extends QuartzDatabaseTestSupport {
+    boolean testConnectionProviderClass = false;
+
+    @Test
+    public void testHikariCpPoolProviderWithExtraProps() throws Exception {
+        validateHikariCpPoolProviderClassWithExtraProps();
+
+        // Turn flag on for next test.
+        testConnectionProviderClass = true;
+    }
+
+    @Test
+    public void testHikariCpPoolProviderClassWithExtraProps() throws Exception {
+        validateHikariCpPoolProviderClassWithExtraProps();
+
+        // Turn flag off for next test.
+        testConnectionProviderClass = false;
+    }
+
+    private void validateHikariCpPoolProviderClassWithExtraProps() throws Exception {
+        DBConnectionManager dbManager = DBConnectionManager.getInstance();
+        ConnectionProvider provider = dbManager.getConnectionProvider("myDS");
+
+        HikariDataSource ds = ((HikariCpPoolingConnectionProvider)provider).getDataSource();
+
+        Assert.assertThat(ds.getDriverClassName(), Matchers.is("org.apache.derby.jdbc.ClientDriver"));
+        Assert.assertThat(ds.getJdbcUrl(), Matchers.is(JdbcQuartzDerbyUtilities.DATABASE_CONNECTION_PREFIX));
+        Assert.assertThat(ds.getUsername(), Matchers.is("quartz"));
+        Assert.assertThat(ds.getPassword(), Matchers.is("quartz"));
+        Assert.assertThat(ds.getMaximumPoolSize(), Matchers.is(5));
+
+        Assert.assertThat(ds.getTransactionIsolation(), Matchers.is("TRANSACTION_REPEATABLE_READ"));
+        Assert.assertThat(ds.isReadOnly(), Matchers.is(false));
+        Assert.assertThat(ds.isAutoCommit(), Matchers.is(false));
+    }
+
+
+
+    @Override
+    protected Properties createSchedulerProperties() {
+        Properties properties = new Properties();
+        properties.put("org.quartz.scheduler.instanceName","TestScheduler");
+        properties.put("org.quartz.scheduler.instanceId","AUTO");
+        properties.put("org.quartz.scheduler.skipUpdateCheck","true");
+        properties.put("org.quartz.threadPool.class","org.quartz.simpl.SimpleThreadPool");
+        properties.put("org.quartz.threadPool.threadCount","12");
+        properties.put("org.quartz.threadPool.threadPriority","5");
+        properties.put("org.quartz.jobStore.misfireThreshold","10000");
+        properties.put("org.quartz.jobStore.class","org.quartz.impl.jdbcjobstore.JobStoreTX");
+        properties.put("org.quartz.jobStore.driverDelegateClass","org.quartz.impl.jdbcjobstore.StdJDBCDelegate");
+        properties.put("org.quartz.jobStore.useProperties","true");
+        properties.put("org.quartz.jobStore.dataSource","myDS");
+        properties.put("org.quartz.jobStore.tablePrefix","QRTZ_");
+        properties.put("org.quartz.jobStore.isClustered", "false");
+
+        properties.put("org.quartz.dataSource.myDS.provider", "hikaricp");
+
+        if (testConnectionProviderClass)
+            properties.put("org.quartz.dataSource.myDS.connectionProvider.class", "org.quartz.utils.HikariCpPoolingConnectionProvider");
+
+        properties.put("org.quartz.dataSource.myDS.provider", "hikaricp");
+        properties.put("org.quartz.dataSource.myDS.driver", "org.apache.derby.jdbc.ClientDriver");
+        properties.put("org.quartz.dataSource.myDS.URL",JdbcQuartzDerbyUtilities.DATABASE_CONNECTION_PREFIX);
+        properties.put("org.quartz.dataSource.myDS.username","quartz");
+        properties.put("org.quartz.dataSource.myDS.password","quartz");
+        properties.put("org.quartz.dataSource.myDS.maxConnections","5");
+
+        // Set extra properties
+        properties.put("org.quartz.dataSource.myDS.transactionIsolation","TRANSACTION_REPEATABLE_READ");
+        properties.put("org.quartz.dataSource.myDS.readOnly","false");
+        properties.put("org.quartz.dataSource.myDS.autoCommit","false");
+
+        return properties;
+    }
+}


### PR DESCRIPTION
Replaces #20 
Add a connection provider for HikariCP
Update to latest C3p0
Break static dependecies on C3p0 so that it isn't required on the class path even if you're not using it

Also addresses minor concerns in #19 