### PR TITLE
correct the annotation

### DIFF
--- a/quartz-core/src/main/java/org/quartz/JobBuilder.java
+++ b/quartz-core/src/main/java/org/quartz/JobBuilder.java
@@ -198,6 +198,7 @@ public class JobBuilder {
      * 
      * <p>
      * If not explicitly set, the default value is <code>false</code>.
+     * - this method sets the value to <code>true</code>.
      * </p>
      * 
      * @return the updated JobBuilder


### PR DESCRIPTION
The original annotation of method JobBuilder#requestRecovery() is ambiguous.  The method do the 'recovery' setting actually. 