### PR TITLE
Skip checkstyle on the examples module

### DIFF
--- a/distribution/examples/pom.xml
+++ b/distribution/examples/pom.xml
@@ -17,6 +17,7 @@
   <properties>
     <skipDeploy>true</skipDeploy>
     <skipJavadoc>true</skipJavadoc>
+    <skipCheckstyle>true</skipCheckstyle>
     <mainClass>org.quartz.examples.example1.SimpleExample</mainClass>
   </properties>
 


### PR DESCRIPTION
Skipping checkstyle on the examples was forgotten, and that breaks the kit build.