### PR TITLE
QuartzInitializerListener: fix a typo

### DIFF
--- a/quartz-core/src/main/java/org/quartz/ee/servlet/QuartzInitializerListener.java
+++ b/quartz-core/src/main/java/org/quartz/ee/servlet/QuartzInitializerListener.java
@@ -160,7 +160,7 @@ public class QuartzInitializerListener implements ServletContextListener {
                 performShutdown = Boolean.valueOf(shutdownPref).booleanValue();
             }
             String shutdownWaitPref = servletContext.getInitParameter("quartz:wait-on-shutdown");
-            if (shutdownPref != null) {
+            if (shutdownWaitPref != null) {
                 waitOnShutdown = Boolean.valueOf(shutdownWaitPref).booleanValue();
             }
 


### PR DESCRIPTION
It seems that the shutdownWaitPref variable should be null-checked instead of shutdownPref variable, that was checked few rows before.