### PR TITLE
Changed varchar length TRIGGER_NAME from 80 to 200

### DIFF
--- a/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/tables_sybase.sql
+++ b/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/tables_sybase.sql
@@ -114,7 +114,7 @@ go
 
 create table QRTZ_CRON_TRIGGERS (
 SCHED_NAME varchar(120) not null,
-TRIGGER_NAME varchar(80) not null,
+TRIGGER_NAME varchar(200) not null,
 TRIGGER_GROUP varchar(80) not null,
 CRON_EXPRESSION varchar(120) not null,
 TIME_ZONE_ID varchar(80) null,
@@ -130,7 +130,7 @@ go
 create table QRTZ_FIRED_TRIGGERS(
 SCHED_NAME varchar(120) not null,
 ENTRY_ID varchar(95) not null,
-TRIGGER_NAME varchar(80) not null,
+TRIGGER_NAME varchar(200) not null,
 TRIGGER_GROUP varchar(80) not null,
 INSTANCE_NAME varchar(80) not null,
 FIRED_TIME numeric(13,0) not null,
@@ -175,7 +175,7 @@ go
 
 create table QRTZ_SIMPLE_TRIGGERS (
 SCHED_NAME varchar(120) not null,
-TRIGGER_NAME varchar(80) not null,
+TRIGGER_NAME varchar(200) not null,
 TRIGGER_GROUP varchar(80) not null,
 REPEAT_COUNT numeric(13,0) not null,
 REPEAT_INTERVAL numeric(13,0) not null,
@@ -204,7 +204,7 @@ go
 
 create table QRTZ_BLOB_TRIGGERS (
 SCHED_NAME varchar(120) not null,
-TRIGGER_NAME varchar(80) not null,
+TRIGGER_NAME varchar(200) not null,
 TRIGGER_GROUP varchar(80) not null,
 BLOB_DATA image null
 )
@@ -212,7 +212,7 @@ go
 
 create table QRTZ_TRIGGERS (
 SCHED_NAME varchar(120) not null,
-TRIGGER_NAME varchar(80) not null,
+TRIGGER_NAME varchar(200) not null,
 TRIGGER_GROUP varchar(80) not null,
 JOB_NAME varchar(80) not null,
 JOB_GROUP varchar(80) not null,


### PR DESCRIPTION
After deploying quartz to a Sybase database the following error occured:

```
Error exec quartz initialisation com.sybase.jdbc4.jdbc.SybBatchUpdateException: JZ0BE: BatchUpdateException: Error occurred while executing batch statement: Column lengths of string type referencing and referenced columns don't match. referencing column = 'TRIGGER_NAME', referenced column = 'TRIGGER_NAME'. 
```

After researching I found out that [tables_sybase.sql](https://github.com/quartz-scheduler/quartz/blob/master/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/tables_sybase.sql) is using `TRIGGER_NAME varchar(80)` instead of `TRIGGER_NAME varchar(200)`. Length should be equivalent to [tables_mysql.sql](https://github.com/quartz-scheduler/quartz/blob/master/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/tables_mysql.sql).

Thanks to @iDschepe figuring this out.