### PR TITLE
Fix XMLSchedulingDataProcessor to compile with Java 10

### DIFF
--- a/quartz-core/src/main/java/org/quartz/xml/XMLSchedulingDataProcessor.java
+++ b/quartz-core/src/main/java/org/quartz/xml/XMLSchedulingDataProcessor.java
@@ -195,7 +195,7 @@ public class XMLSchedulingDataProcessor implements ErrorHandler {
               return XMLConstants.NULL_NS_URI;
           }
         
-          public Iterator<?> getPrefixes(String namespaceURI)
+          public Iterator<String> getPrefixes(String namespaceURI)
           {
               // This method isn't necessary for XPath processing.
               throw new UnsupportedOperationException();


### PR DESCRIPTION
Hi,

The return type of the `getPrefixes​()` method  of `javax.xml.namespace.NamespaceContext` changed in Java 10 from `List` to `List<String>`. This causes a compilation error in XMLSchedulingDataProcessor. Here is a fix addressing this issue.