### PR TITLE
Use all-caps table names in the liquibase script

### DIFF
--- a/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/liquibase.quartz.init.xml
+++ b/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/liquibase.quartz.init.xml
@@ -4,349 +4,349 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="quartz-init" author="nasazh">
-        <createTable tableName="qrtz_tdss_locks">
-            <column name="sched_name" type="VARCHAR(120)">
+        <createTable tableName="QRTZ_LOCKS">
+            <column name="SCHED_NAME" type="VARCHAR(120)">
                 <constraints nullable="false"/>
             </column>
-            <column name="lock_name" type="VARCHAR(40)">
-                <constraints nullable="false"/>
-            </column>
-        </createTable>
-        <addPrimaryKey columnNames="sched_name, lock_name" tableName="qrtz_tdss_locks"/>
-
-        <createTable tableName="qrtz_tdss_fired_triggers">
-            <column name="sched_name" type="VARCHAR(120)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="entry_id" type="VARCHAR(95)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_name" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_group" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="instance_name" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="fired_time" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="sched_time" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="priority" type="INTEGER">
-                <constraints nullable="false"/>
-            </column>
-            <column name="state" type="VARCHAR(16)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="job_name" type="VARCHAR(200)"/>
-            <column name="job_group" type="VARCHAR(200)"/>
-            <column name="is_nonconcurrent" type="BOOLEAN"/>
-            <column name="requests_recovery" type="BOOLEAN"/>
-        </createTable>
-        <addPrimaryKey columnNames="sched_name, entry_id" tableName="qrtz_tdss_fired_triggers"/>
-
-        <createIndex tableName="qrtz_tdss_fired_triggers" indexName="idx_qrtz_tdss_ft_inst_job_req_rcvry">
-            <column name="sched_name"/>
-            <column name="instance_name"/>
-            <column name="requests_recovery"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_fired_triggers" indexName="idx_qrtz_tdss_ft_j_g">
-            <column name="sched_name"/>
-            <column name="job_name"/>
-            <column name="job_group"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_fired_triggers" indexName="idx_qrtz_tdss_ft_jg">
-            <column name="sched_name"/>
-            <column name="job_group"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_fired_triggers" indexName="idx_qrtz_tdss_ft_t_g">
-            <column name="sched_name"/>
-            <column name="trigger_name"/>
-            <column name="trigger_group"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_fired_triggers" indexName="idx_qrtz_tdss_ft_tg">
-            <column name="sched_name"/>
-            <column name="trigger_group"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_fired_triggers" indexName="idx_qrtz_tdss_ft_trig_inst_name">
-            <column name="sched_name"/>
-            <column name="instance_name"/>
-        </createIndex>
-
-        <createTable tableName="qrtz_tdss_calendars">
-            <column name="sched_name" type="VARCHAR(120)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="calendar_name" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="calendar" type="blob">
+            <column name="LOCK_NAME" type="VARCHAR(40)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey columnNames="sched_name, calendar_name" tableName="qrtz_tdss_calendars"/>
+        <addPrimaryKey columnNames="SCHED_NAME, LOCK_NAME" tableName="QRTZ_LOCKS"/>
 
-        <createTable tableName="qrtz_tdss_paused_trigger_grps">
-            <column name="sched_name" type="VARCHAR(120)">
+        <createTable tableName="QRTZ_FIRED_TRIGGERS">
+            <column name="SCHED_NAME" type="VARCHAR(120)">
                 <constraints nullable="false"/>
             </column>
-            <column name="trigger_group" type="VARCHAR(200)">
+            <column name="ENTRY_ID" type="VARCHAR(95)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_NAME" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="INSTANCE_NAME" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="FIRED_TIME" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="SCHED_TIME" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="PRIORITY" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="STATE" type="VARCHAR(16)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_NAME" type="VARCHAR(200)"/>
+            <column name="JOB_GROUP" type="VARCHAR(200)"/>
+            <column name="IS_NONCONCURRENT" type="BOOLEAN"/>
+            <column name="REQUESTS_RECOVERY" type="BOOLEAN"/>
+        </createTable>
+        <addPrimaryKey columnNames="SCHED_NAME, ENTRY_ID" tableName="QRTZ_FIRED_TRIGGERS"/>
+
+        <createIndex tableName="QRTZ_FIRED_TRIGGERS" indexName="IDX_QRTZ_FT_INST_JOB_REQ_RCVRY">
+            <column name="SCHED_NAME"/>
+            <column name="INSTANCE_NAME"/>
+            <column name="REQUESTS_RECOVERY"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_FIRED_TRIGGERS" indexName="IDX_QRTZ_FT_J_G">
+            <column name="SCHED_NAME"/>
+            <column name="JOB_NAME"/>
+            <column name="JOB_GROUP"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_FIRED_TRIGGERS" indexName="IDX_QRTZ_FT_JG">
+            <column name="SCHED_NAME"/>
+            <column name="JOB_GROUP"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_FIRED_TRIGGERS" indexName="IDX_QRTZ_FT_T_G">
+            <column name="SCHED_NAME"/>
+            <column name="TRIGGER_NAME"/>
+            <column name="TRIGGER_GROUP"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_FIRED_TRIGGERS" indexName="IDX_QRTZ_FT_TG">
+            <column name="SCHED_NAME"/>
+            <column name="TRIGGER_GROUP"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_FIRED_TRIGGERS" indexName="IDX_QRTZ_FT_TRIG_INST_NAME">
+            <column name="SCHED_NAME"/>
+            <column name="INSTANCE_NAME"/>
+        </createIndex>
+
+        <createTable tableName="QRTZ_CALENDARS">
+            <column name="SCHED_NAME" type="VARCHAR(120)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CALENDAR_NAME" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CALENDAR" type="blob">
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey columnNames="sched_name, trigger_group" tableName="qrtz_tdss_paused_trigger_grps"/>
+        <addPrimaryKey columnNames="SCHED_NAME, CALENDAR_NAME" tableName="QRTZ_CALENDARS"/>
 
-        <createTable tableName="qrtz_tdss_scheduler_state">
-            <column name="sched_name" type="VARCHAR(120)">
+        <createTable tableName="QRTZ_PAUSED_TRIGGER_GRPS">
+            <column name="SCHED_NAME" type="VARCHAR(120)">
                 <constraints nullable="false"/>
             </column>
-            <column name="instance_name" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="last_checkin_time" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="checkin_interval" type="BIGINT">
+            <column name="TRIGGER_GROUP" type="VARCHAR(200)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey columnNames="sched_name, instance_name" tableName="qrtz_tdss_scheduler_state"/>
+        <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_GROUP" tableName="QRTZ_PAUSED_TRIGGER_GRPS"/>
 
-        <createTable tableName="qrtz_tdss_job_details">
-            <column name="sched_name" type="VARCHAR(120)">
+        <createTable tableName="QRTZ_SCHEDULER_STATE">
+            <column name="SCHED_NAME" type="VARCHAR(120)">
                 <constraints nullable="false"/>
             </column>
-            <column name="job_name" type="VARCHAR(200)">
+            <column name="INSTANCE_NAME" type="VARCHAR(200)">
                 <constraints nullable="false"/>
             </column>
-            <column name="job_group" type="VARCHAR(200)">
+            <column name="LAST_CHECKIN_TIME" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="description" type="VARCHAR(250)"/>
-            <column name="job_class_name" type="VARCHAR(250)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="is_durable" type="BOOLEAN">
-                <constraints nullable="false"/>
-            </column>
-            <column name="is_nonconcurrent" type="BOOLEAN">
-                <constraints nullable="false"/>
-            </column>
-            <column name="is_update_data" type="BOOLEAN">
-                <constraints nullable="false"/>
-            </column>
-            <column name="requests_recovery" type="BOOLEAN">
-                <constraints nullable="false"/>
-            </column>
-            <column name="job_data" type="blob"/>
-        </createTable>
-        <addPrimaryKey columnNames="sched_name, job_name, job_group" tableName="qrtz_tdss_job_details"/>
-
-        <createIndex tableName="qrtz_tdss_job_details" indexName="idx_qrtz_tdss_j_grp">
-            <column name="sched_name"/>
-            <column name="job_group"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_job_details" indexName="idx_qrtz_tdss_j_req_recovery">
-            <column name="sched_name"/>
-            <column name="requests_recovery"/>
-        </createIndex>
-
-        <createTable tableName="qrtz_tdss_triggers">
-            <column name="sched_name" type="VARCHAR(120)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_name" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_group" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="job_name" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="job_group" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="description" type="VARCHAR(250)"/>
-            <column name="next_fire_time" type="BIGINT"/>
-            <column name="prev_fire_time" type="BIGINT"/>
-            <column name="priority" type="INTEGER"/>
-            <column name="trigger_state" type="VARCHAR(16)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_type" type="VARCHAR(8)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="start_time" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="end_time" type="BIGINT"/>
-            <column name="calendar_name" type="VARCHAR(200)"/>
-            <column name="misfire_instr" type="SMALLINT"/>
-            <column name="job_data" type="blob"/>
-        </createTable>
-        <addPrimaryKey columnNames="sched_name, trigger_name, trigger_group" tableName="qrtz_tdss_triggers"/>
-
-        <createIndex tableName="qrtz_tdss_triggers" indexName="idx_qrtz_tdss_t_c">
-            <column name="sched_name"/>
-            <column name="calendar_name"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_triggers" indexName="idx_qrtz_tdss_t_g">
-            <column name="sched_name"/>
-            <column name="trigger_group"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_triggers" indexName="idx_qrtz_tdss_t_jg">
-            <column name="sched_name"/>
-            <column name="job_group"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_triggers" indexName="idx_qrtz_tdss_t_n_g_state">
-            <column name="sched_name"/>
-            <column name="trigger_group"/>
-            <column name="trigger_state"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_triggers" indexName="idx_qrtz_tdss_t_n_state">
-            <column name="sched_name"/>
-            <column name="trigger_name"/>
-            <column name="trigger_group"/>
-            <column name="trigger_state"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_triggers" indexName="idx_qrtz_tdss_t_next_fire_time">
-            <column name="sched_name"/>
-            <column name="next_fire_time"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_triggers" indexName="idx_qrtz_tdss_t_nft_misfire">
-            <column name="sched_name"/>
-            <column name="misfire_instr"/>
-            <column name="next_fire_time"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_triggers" indexName="idx_qrtz_tdss_t_nft_st">
-            <column name="sched_name"/>
-            <column name="trigger_state"/>
-            <column name="next_fire_time"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_triggers" indexName="idx_qrtz_tdss_t_nft_st_misfire">
-            <column name="sched_name"/>
-            <column name="misfire_instr"/>
-            <column name="next_fire_time"/>
-            <column name="trigger_state"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_triggers" indexName="idx_qrtz_tdss_t_nft_st_misfire_grp">
-            <column name="sched_name"/>
-            <column name="misfire_instr"/>
-            <column name="next_fire_time"/>
-            <column name="trigger_group"/>
-            <column name="trigger_state"/>
-        </createIndex>
-
-        <createIndex tableName="qrtz_tdss_triggers" indexName="idx_qrtz_tdss_t_state">
-            <column name="sched_name"/>
-            <column name="trigger_state"/>
-        </createIndex>
-
-        <createTable tableName="qrtz_tdss_blob_triggers">
-            <column name="sched_name" type="VARCHAR(120)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_name" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_group" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="blob_data" type="blob"/>
-        </createTable>
-        <addPrimaryKey columnNames="sched_name, trigger_name, trigger_group" tableName="qrtz_tdss_blob_triggers"/>
-
-        <createTable tableName="qrtz_tdss_simprop_triggers">
-            <column name="sched_name" type="VARCHAR(120)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_name" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_group" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="str_prop_1" type="VARCHAR(512)"/>
-            <column name="str_prop_2" type="VARCHAR(512)"/>
-            <column name="str_prop_3" type="VARCHAR(512)"/>
-            <column name="int_prop_1" type="INTEGER"/>
-            <column name="int_prop_2" type="INTEGER"/>
-            <column name="long_prop_1" type="BIGINT"/>
-            <column name="long_prop_2" type="BIGINT"/>
-            <column name="dec_prop_1" type="NUMERIC(13,4)"/>
-            <column name="dec_prop_2" type="NUMERIC(13,4)"/>
-            <column name="bool_prop_1" type="BOOLEAN"/>
-            <column name="bool_prop_2" type="BOOLEAN"/>
-        </createTable>
-        <addPrimaryKey columnNames="sched_name, trigger_name, trigger_group" tableName="qrtz_tdss_simprop_triggers"/>
-
-        <createTable tableName="qrtz_tdss_cron_triggers">
-            <column name="sched_name" type="VARCHAR(120)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_name" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_group" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cron_expression" type="VARCHAR(120)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="time_zone_id" type="VARCHAR(80)"/>
-        </createTable>
-        <addPrimaryKey columnNames="sched_name, trigger_name, trigger_group" tableName="qrtz_tdss_cron_triggers"/>
-
-        <createTable tableName="qrtz_tdss_simple_triggers">
-            <column name="sched_name" type="VARCHAR(120)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_name" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="trigger_group" type="VARCHAR(200)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="repeat_count" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="repeat_interval" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="times_triggered" type="BIGINT">
+            <column name="CHECKIN_INTERVAL" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey columnNames="sched_name, trigger_name, trigger_group" tableName="qrtz_tdss_simple_triggers"/>
+        <addPrimaryKey columnNames="SCHED_NAME, INSTANCE_NAME" tableName="QRTZ_SCHEDULER_STATE"/>
 
-        <addForeignKeyConstraint baseTableName="qrtz_tdss_triggers" constraintName="qrtz_tdss_triggers_sched_name_fkey" baseColumnNames="sched_name, job_name, job_group" referencedTableName="qrtz_tdss_job_details" referencedColumnNames="sched_name, job_name, job_group"/>
+        <createTable tableName="QRTZ_JOB_DETAILS">
+            <column name="SCHED_NAME" type="VARCHAR(120)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_NAME" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_GROUP" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="DESCRIPTION" type="VARCHAR(250)"/>
+            <column name="JOB_CLASS_NAME" type="VARCHAR(250)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="IS_DURABLE" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="IS_NONCONCURRENT" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="IS_UPDATE_DATA" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="REQUESTS_RECOVERY" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_DATA" type="blob"/>
+        </createTable>
+        <addPrimaryKey columnNames="SCHED_NAME, JOB_NAME, JOB_GROUP" tableName="QRTZ_JOB_DETAILS"/>
 
-        <addForeignKeyConstraint baseTableName="qrtz_tdss_simple_triggers" constraintName="qrtz_tdss_simple_triggers_sched_name_fkey" baseColumnNames="sched_name, trigger_name, trigger_group" referencedTableName="qrtz_tdss_triggers" referencedColumnNames="sched_name, trigger_name, trigger_group"/>
+        <createIndex tableName="QRTZ_JOB_DETAILS" indexName="IDX_QRTZ_J_GRP">
+            <column name="SCHED_NAME"/>
+            <column name="JOB_GROUP"/>
+        </createIndex>
 
-        <addForeignKeyConstraint baseTableName="qrtz_tdss_cron_triggers" constraintName="qrtz_tdss_cron_triggers_sched_name_fkey" baseColumnNames="sched_name, trigger_name, trigger_group" referencedTableName="qrtz_tdss_triggers" referencedColumnNames="sched_name, trigger_name, trigger_group"/>
+        <createIndex tableName="QRTZ_JOB_DETAILS" indexName="IDX_QRTZ_J_REQ_RECOVERY">
+            <column name="SCHED_NAME"/>
+            <column name="REQUESTS_RECOVERY"/>
+        </createIndex>
 
-        <addForeignKeyConstraint baseTableName="qrtz_tdss_simprop_triggers" constraintName="qrtz_tdss_simprop_triggers_sched_name_fkey" baseColumnNames="sched_name, trigger_name, trigger_group" referencedTableName="qrtz_tdss_triggers" referencedColumnNames="sched_name, trigger_name, trigger_group"/>
+        <createTable tableName="QRTZ_TRIGGERS">
+            <column name="SCHED_NAME" type="VARCHAR(120)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_NAME" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_NAME" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_GROUP" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="DESCRIPTION" type="VARCHAR(250)"/>
+            <column name="NEXT_FIRE_TIME" type="BIGINT"/>
+            <column name="PREV_FIRE_TIME" type="BIGINT"/>
+            <column name="PRIORITY" type="INTEGER"/>
+            <column name="TRIGGER_STATE" type="VARCHAR(16)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_TYPE" type="VARCHAR(8)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="START_TIME" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="END_TIME" type="BIGINT"/>
+            <column name="CALENDAR_NAME" type="VARCHAR(200)"/>
+            <column name="MISFIRE_INSTR" type="smallint"/>
+            <column name="JOB_DATA" type="blob"/>
+        </createTable>
+        <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" tableName="QRTZ_TRIGGERS"/>
 
-        <addForeignKeyConstraint baseTableName="qrtz_tdss_blob_triggers" constraintName="qrtz_tdss_blob_triggers_sched_name_fkey" baseColumnNames="sched_name, trigger_name, trigger_group" referencedTableName="qrtz_tdss_triggers" referencedColumnNames="sched_name, trigger_name, trigger_group"/>
+        <createIndex tableName="QRTZ_TRIGGERS" indexName="IDX_QRTZ_T_C">
+            <column name="SCHED_NAME"/>
+            <column name="CALENDAR_NAME"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_TRIGGERS" indexName="IDX_QRTZ_T_G">
+            <column name="SCHED_NAME"/>
+            <column name="TRIGGER_GROUP"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_TRIGGERS" indexName="IDX_QRTZ_T_JG">
+            <column name="SCHED_NAME"/>
+            <column name="JOB_GROUP"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_TRIGGERS" indexName="IDX_QRTZ_T_N_G_STATE">
+            <column name="SCHED_NAME"/>
+            <column name="TRIGGER_GROUP"/>
+            <column name="TRIGGER_STATE"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_TRIGGERS" indexName="IDX_QRTZ_T_N_STATE">
+            <column name="SCHED_NAME"/>
+            <column name="TRIGGER_NAME"/>
+            <column name="TRIGGER_GROUP"/>
+            <column name="TRIGGER_STATE"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_TRIGGERS" indexName="IDX_QRTZ_T_NEXT_FIRE_TIME">
+            <column name="SCHED_NAME"/>
+            <column name="NEXT_FIRE_TIME"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_TRIGGERS" indexName="IDX_QRTZ_T_NFT_MISFIRE">
+            <column name="SCHED_NAME"/>
+            <column name="MISFIRE_INSTR"/>
+            <column name="NEXT_FIRE_TIME"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_TRIGGERS" indexName="IDX_QRTZ_T_NFT_ST">
+            <column name="SCHED_NAME"/>
+            <column name="TRIGGER_STATE"/>
+            <column name="NEXT_FIRE_TIME"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_TRIGGERS" indexName="IDX_QRTZ_T_NFT_ST_MISFIRE">
+            <column name="SCHED_NAME"/>
+            <column name="MISFIRE_INSTR"/>
+            <column name="NEXT_FIRE_TIME"/>
+            <column name="TRIGGER_STATE"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_TRIGGERS" indexName="IDX_QRTZ_T_NFT_ST_MISFIRE_GRP">
+            <column name="SCHED_NAME"/>
+            <column name="MISFIRE_INSTR"/>
+            <column name="NEXT_FIRE_TIME"/>
+            <column name="TRIGGER_GROUP"/>
+            <column name="TRIGGER_STATE"/>
+        </createIndex>
+
+        <createIndex tableName="QRTZ_TRIGGERS" indexName="IDX_QRTZ_T_STATE">
+            <column name="SCHED_NAME"/>
+            <column name="TRIGGER_STATE"/>
+        </createIndex>
+
+        <createTable tableName="QRTZ_BLOB_TRIGGERS">
+            <column name="SCHED_NAME" type="VARCHAR(120)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_NAME" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="BLOB_DATA" type="blob"/>
+        </createTable>
+        <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" tableName="QRTZ_BLOB_TRIGGERS"/>
+
+        <createTable tableName="QRTZ_SIMPROP_TRIGGERS">
+            <column name="SCHED_NAME" type="VARCHAR(120)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_NAME" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="STR_PROP_1" type="VARCHAR(512)"/>
+            <column name="STR_PROP_2" type="VARCHAR(512)"/>
+            <column name="STR_PROP_3" type="VARCHAR(512)"/>
+            <column name="INT_PROP_1" type="INTEGER"/>
+            <column name="INT_PROP_2" type="INTEGER"/>
+            <column name="LONG_PROP_1" type="BIGINT"/>
+            <column name="LONG_PROP_2" type="BIGINT"/>
+            <column name="DEC_PROP_1" type="NUMERIC(13,4)"/>
+            <column name="DEC_PROP_2" type="NUMERIC(13,4)"/>
+            <column name="BOOL_PROP_1" type="BOOLEAN"/>
+            <column name="BOOL_PROP_2" type="BOOLEAN"/>
+        </createTable>
+        <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" tableName="QRTZ_SIMPROP_TRIGGERS"/>
+
+        <createTable tableName="QRTZ_CRON_TRIGGERS">
+            <column name="SCHED_NAME" type="VARCHAR(120)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_NAME" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CRON_EXPRESSION" type="VARCHAR(120)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TIME_ZONE_ID" type="VARCHAR(80)"/>
+        </createTable>
+        <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" tableName="QRTZ_CRON_TRIGGERS"/>
+
+        <createTable tableName="QRTZ_SIMPLE_TRIGGERS">
+            <column name="SCHED_NAME" type="VARCHAR(120)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_NAME" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="REPEAT_COUNT" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="REPEAT_INTERVAL" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TIMES_TRIGGERED" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" tableName="QRTZ_SIMPLE_TRIGGERS"/>
+
+        <addForeignKeyConstraint baseTableName="QRTZ_TRIGGERS" constraintName="QRTZ_TRIGGERS_SCHED_NAME_FKEY" baseColumnNames="SCHED_NAME, JOB_NAME, JOB_GROUP" referencedTableName="QRTZ_JOB_DETAILS" referencedColumnNames="SCHED_NAME, JOB_NAME, JOB_GROUP"/>
+
+        <addForeignKeyConstraint baseTableName="QRTZ_SIMPLE_TRIGGERS" constraintName="QRTZ_SIMPLE_TRIGGERS_SCHED_NAME_FKEY" baseColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" referencedTableName="QRTZ_TRIGGERS" referencedColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP"/>
+
+        <addForeignKeyConstraint baseTableName="QRTZ_CRON_TRIGGERS" constraintName="QRTZ_CRON_TRIGGERS_SCHED_NAME_FKEY" baseColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" referencedTableName="QRTZ_TRIGGERS" referencedColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP"/>
+
+        <addForeignKeyConstraint baseTableName="QRTZ_SIMPROP_TRIGGERS" constraintName="QRTZ_SIMPROP_TRIGGERS_SCHED_NAME_FKEY" baseColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" referencedTableName="QRTZ_TRIGGERS" referencedColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP"/>
+
+        <addForeignKeyConstraint baseTableName="QRTZ_BLOB_TRIGGERS" constraintName="QRTZ_BLOB_TRIGGERS_SCHED_NAME_FKEY" baseColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" referencedTableName="QRTZ_TRIGGERS" referencedColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
On case-sensitive databases, the table names in the Liquibase script cause issues, since they're all lower case. This change fixes that.

It also removes the `tdss` prefix from the table names.