### PR TITLE
Fix ConcurrentModificationException in StdSchedulerFactory

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/StdSchedulerFactory.java
+++ b/quartz-core/src/main/java/org/quartz/impl/StdSchedulerFactory.java
@@ -65,6 +65,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.security.AccessControlException;
 import java.util.Collection;
+import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Properties;
 
@@ -469,19 +470,20 @@ public class StdSchedulerFactory implements SchedulerFactory {
             }
         }
 
-        initialize(overrideWithSysProps(props));
+        initialize(overrideWithSysProps(props, getLog()));
     }
 
     /**
      * Add all System properties to the given <code>props</code>.  Will override
      * any properties that already exist in the given <code>props</code>.
      */
-    private Properties overrideWithSysProps(Properties props) {
+    // Visible for testing
+    static Properties overrideWithSysProps(Properties props, Logger log) {
         Properties sysProps = null;
         try {
             sysProps = System.getProperties();
         } catch (AccessControlException e) {
-            getLog().warn(
+            log.warn(
                 "Skipping overriding quartz properties with System properties " +
                 "during initialization because of an AccessControlException.  " +
                 "This is likely due to not having read/write access for " +
@@ -492,7 +494,17 @@ public class StdSchedulerFactory implements SchedulerFactory {
         }
 
         if (sysProps != null) {
-            props.putAll(sysProps);
+            // Use the propertyNames to iterate to avoid 
+            // a possible ConcurrentModificationException
+            Enumeration<?> en = sysProps.propertyNames();
+            while (en.hasMoreElements()) {
+                Object name = en.nextElement();
+                Object value = sysProps.get(name);
+                if (value != null && name instanceof String && value instanceof String) {
+                    // Properties javadoc discourages use of put so we use setProperty
+                    props.setProperty((String) name, (String) value);
+                }
+            }
         }
 
         return props;

--- a/quartz-core/src/test/java/org/quartz/impl/StdSchedulerFactoryTest.java
+++ b/quartz-core/src/test/java/org/quartz/impl/StdSchedulerFactoryTest.java
@@ -17,9 +17,13 @@ package org.quartz.impl;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Properties;
+
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
+import org.slf4j.Logger;
 
 /**
  * TestCase to verify StdSchedulerFactory initializes correctly a custom ConnectionProvider
@@ -28,7 +32,7 @@ import org.quartz.SchedulerException;
  *
  */
 
-public class StdSchedulerFactoryCustomConnectionProviderTest {
+public class StdSchedulerFactoryTest {
 
 	@Test
 	public void loadAndInitializeCustomConnectionProviderTest() throws SchedulerException, InterruptedException {
@@ -45,5 +49,17 @@ public class StdSchedulerFactoryCustomConnectionProviderTest {
 		assertEquals("getConnection",MockConnectionProvider.methodsCalled.get(2));
 	}
 	
+	
+	@Test
+	public void testOverrideSystemProperties() {
+	    Properties p = new Properties();
+	    p.setProperty("nonsense1", "hello1");
+	    p.setProperty("nonsense2", "hello2");
+	    System.setProperty("nonsense1", "boo1");
+	    String osName = System.getProperty("os.name");
+	    Properties q = StdSchedulerFactory.overrideWithSysProps(p, Mockito.mock(Logger.class));
+	    assertEquals("boo1", q.get("nonsense1"));
+	    assertEquals(osName, q.get("os.name"));
+	}
 
 }


### PR DESCRIPTION
Discussed in #474 

* Used `propertyNames()` to iterate System properties instead of the `entrySet()` (via `putAll`) to avoid a `ConcurrentModificationException`
* Added unit test for coverage of new code

I've not added a unit test that provoked a CME because it involves a race condition that is fiddly to provoke.
