### PR TITLE
Add ability to use JobStore separately from QuartzScheduler

### DIFF
--- a/quartz-core/src/main/java/org/quartz/TriggerUtils.java
+++ b/quartz-core/src/main/java/org/quartz/TriggerUtils.java
@@ -18,10 +18,9 @@
 
 package org.quartz;
 
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
+import org.quartz.spi.JobStore;
 import org.quartz.spi.OperableTrigger;
 
 /**
@@ -198,4 +197,41 @@ public class TriggerUtils {
         return java.util.Collections.unmodifiableList(lst);
     }
 
+    /**
+     * Make sure all triggers refer to their associated job.
+     */
+    public static void associateTriggersAndJobs(
+            Map<JobDetail, Set<? extends Trigger>> triggersAndJobs,
+            JobStore jobStore
+    ) throws SchedulerException{
+        for(Map.Entry<JobDetail, Set<? extends Trigger>> e: triggersAndJobs.entrySet()) {
+            JobDetail job = e.getKey();
+            if(job == null) // there can be one of these (for adding a bulk set of triggers for pre-existing jobs)
+                continue;
+            Set<? extends Trigger> triggers = e.getValue();
+            if(triggers == null) // this is possible because the job may be durable, and not yet be having triggers
+                continue;
+            for(Trigger trigger: triggers) {
+                OperableTrigger opt = (OperableTrigger)trigger;
+                opt.setJobKey(job.getKey());
+
+                opt.validate();
+
+                Calendar cal = null;
+                if (trigger.getCalendarName() != null) {
+                    cal = jobStore.retrieveCalendar(trigger.getCalendarName());
+                    if(cal == null) {
+                        throw new SchedulerException(
+                                "Calendar '" + trigger.getCalendarName() + "' not found for trigger: " + trigger.getKey());
+                    }
+                }
+                Date ft = opt.computeFirstFireTime(cal);
+
+                if (ft == null) {
+                    throw new SchedulerException(
+                            "Based on configured schedule, the given trigger will never fire.");
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
We need to implement custom jdbc job manager. We can not use QuartzScheduler because its life cycle differs from our life cycle of job manager controller, so it is difficult to implement correct jdbc session managment. Actually we need that job controller uses exclusive jdbc session of user thread for security reason.

We have found out that the simplest way to implement job manager is to use JobStoreSupport directly.
Unfortunately currently we cannot do that without code duplication. This pull request add ability to use JobStoreSupport separately without code duplication. 
See: TriggerUtils.associateTriggersAndJobs