### PR TITLE
Return at most maxCount triggers

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
@@ -2612,7 +2612,7 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
             ps.setBigDecimal(3, new BigDecimal(String.valueOf(noEarlierThan)));
             rs = ps.executeQuery();
             
-            while (rs.next() && nextTriggers.size() <= maxCount) {
+            while (rs.next() && nextTriggers.size() < maxCount) {
                 nextTriggers.add(triggerKey(
                         rs.getString(COL_TRIGGER_NAME),
                         rs.getString(COL_TRIGGER_GROUP)));


### PR DESCRIPTION
Addresses Issue: #491

In cases where the JDBC driver does not respect `PreparedStatement.setFetchSize` and `PreparedStatement.setMaxRows`, the current logic may return more than `maxCount` results.