### PR TITLE
modifiy HostnameInstanceIdGenerator.java

### DIFF
--- a/quartz-core/src/main/java/org/quartz/simpl/HostnameInstanceIdGenerator.java
+++ b/quartz-core/src/main/java/org/quartz/simpl/HostnameInstanceIdGenerator.java
@@ -41,6 +41,7 @@ public class HostnameInstanceIdGenerator implements InstanceIdGenerator {
     public String generateInstanceId() throws SchedulerException {
         try {
             return InetAddress.getLocalHost().getHostName();
+            
         } catch (Exception e) {
             throw new SchedulerException("Couldn't get host name!", e);
         }


### PR DESCRIPTION
config
org.quartz.scheduler.instanceId =AUTO

When the host name cannot be obtained, it is recommended to generate one randomly