### PR TITLE
#466 Don't swallow original exception

### DIFF
--- a/quartz-core/src/main/java/org/quartz/CronExpression.java
+++ b/quartz-core/src/main/java/org/quartz/CronExpression.java
@@ -293,7 +293,7 @@ public final class CronExpression implements Serializable, Cloneable {
         try {
             buildExpression(cronExpression);
         } catch (ParseException ex) {
-            throw new AssertionError();
+            throw new AssertionError("Could not parse expression!", ex);
         }
         if (expression.getTimeZone() != null) {
             setTimeZone((TimeZone) expression.getTimeZone().clone());


### PR DESCRIPTION
Do not swallow the original exception during copy/clone, at least wrap it in the new AssertionError so users have actually a chance of seeing what went wrong. 

While this is extremely unlikely to happen the issue report shows that it will happen eventually (for whatever reasons).