### PR TITLE
Fix #453: Pass job data map through the job chain in JobChainingJobListener

### DIFF
--- a/quartz-core/src/main/java/org/quartz/listeners/JobChainingJobListener.java
+++ b/quartz-core/src/main/java/org/quartz/listeners/JobChainingJobListener.java
@@ -96,7 +96,7 @@ public class JobChainingJobListener extends JobListenerSupport {
         getLog().info("Job '" + context.getJobDetail().getKey() + "' will now chain to Job '" + sj + "'");
 
         try {
-             context.getScheduler().triggerJob(sj);
+             context.getScheduler().triggerJob(sj, context.getMergedJobDataMap());
         } catch(SchedulerException se) {
             getLog().error("Error encountered during chaining to Job '" + sj + "'", se);
         }


### PR DESCRIPTION
JobChainingJobListener does not support passing the trigger-specific data to a job in a job chain.

Passing a job data map when triggering the next job in the job chain resolves this issue.