### PR TITLE
Change DB2 schema boolean column type from integer to varchar(1)

### DIFF
--- a/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/tables_db2_v8.sql
+++ b/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/tables_db2_v8.sql
@@ -26,10 +26,10 @@ job_name varchar(80) not null,
 job_group varchar(80) not null,
 description varchar(120),
 job_class_name varchar(128) not null,
-is_durable integer not null,
-is_nonconcurrent integer not null,
-is_update_data integer not null,
-requests_recovery integer not null,
+is_durable varchar(1) not null,
+is_nonconcurrent varchar(1) not null,
+is_update_data varchar(1) not null,
+requests_recovery varchar(1) not null,
 job_data blob(2000),
 primary key (sched_name,job_name,job_group)
 );
@@ -125,8 +125,8 @@ priority integer not null,
 state varchar(16) not null,
 job_name varchar(80),
 job_group varchar(80),
-is_nonconcurrent integer,
-requests_recovery integer,
+is_nonconcurrent varchar(1),
+requests_recovery varchar(1),
 primary key (sched_name,entry_id)
 );
 

--- a/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/tables_db2_v95.sql
+++ b/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/tables_db2_v95.sql
@@ -16,10 +16,10 @@ job_name varchar(80) not null,
 job_group varchar(80) not null,
 description varchar(120),
 job_class_name varchar(128) not null,
-is_durable integer not null,
-is_nonconcurrent integer not null,
-is_update_data integer not null,
-requests_recovery integer not null,
+is_durable varchar(1) not null,
+is_nonconcurrent varchar(1) not null,
+is_update_data varchar(1) not null,
+requests_recovery varchar(1) not null,
 job_data blob(2000),
 primary key (sched_name,job_name,job_group)
 );
@@ -115,8 +115,8 @@ priority integer not null,
 state varchar(16) not null,
 job_name varchar(80),
 job_group varchar(80),
-is_nonconcurrent integer,
-requests_recovery integer,
+is_nonconcurrent varchar(1),
+requests_recovery varchar(1),
 primary key (sched_name,entry_id)
 );
 


### PR DESCRIPTION
In these two db2 schemas (**tables_db2_v8**, **tables_db2_v95**), SQL boolean type is mapped into:
- `varchar(1)` for _BOOL_PROP_1_, _BOOL_PROP_2_ at **qrtz_simprop_triggers** table
- `integer` for _is_durable_, _is_nonconcurrent_, _is_update_data_, _requests_recovery_ at **qrtz_job_details** table and _is_nonconcurrent_, _requests_recovery_ at **qrtz_fired_triggers** table.

Hence, it is impossible to validate those schemas with a tool like Hibernate _hbm2ddl_ "_validate_", as for the same SQL boolean type, there are two different mappings.

My proposal is to unify all of them into `varchar(1)` as it is done in the other two db2 schemas (**tables_db2** and **tables_db2_v72**)

