### PR TITLE
Removing blob column length of 2000 as it fails when executing Quartz jobs

### DIFF
--- a/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/tables_db2.sql
+++ b/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/tables_db2.sql
@@ -10,9 +10,6 @@
 # If you're using DB2 6.x you'll want to set this property to
 # org.quartz.jobStore.driverDelegateClass = org.quartz.impl.jdbcjobstore.DB2v6Delegate
 #
-# Note that the blob column size (e.g. blob(2000)) dictates the amount of data that can be stored in 
-# that blob - i.e. limits the amount of data you can put into your JobDataMap 
-#
 
 
 create table qrtz_job_details (
@@ -25,7 +22,7 @@ create table qrtz_job_details (
   is_nonconcurrent varchar(1) not null,
   is_update_data varchar(1) not null,
   requests_recovery varchar(1) not null,
-  job_data blob(2000),
+  job_data blob,
     primary key (sched_name,job_name,job_group)
 )
 
@@ -45,7 +42,7 @@ create table qrtz_triggers(
   end_time bigint,
   calendar_name varchar(80),
   misfire_instr smallint,
-  job_data blob(2000),
+  job_data blob,
     primary key (sched_name,trigger_name,trigger_group),
     foreign key (sched_name,job_name,job_group) references qrtz_job_details(sched_name,job_name,job_group)
 )
@@ -96,7 +93,7 @@ create table qrtz_blob_triggers(
   sched_name varchar(120) not null,
   trigger_name varchar(80) not null,
   trigger_group varchar(80) not null,
-  blob_data blob(2000) null,
+  blob_data blob null,
     primary key (sched_name,trigger_name,trigger_group),
     foreign key (sched_name,trigger_name,trigger_group) references qrtz_triggers(sched_name,trigger_name,trigger_group)
 )
@@ -104,7 +101,7 @@ create table qrtz_blob_triggers(
 create table qrtz_calendars(
   sched_name varchar(120) not null,
   calendar_name varchar(80) not null,
-  calendar blob(2000) not null,
+  calendar blob not null,
     primary key (sched_name,calendar_name)
 )
 


### PR DESCRIPTION
From Red Hat, we using Quartz version 2.2.3 in our jBPM project version 7.x. 

When making use of Quartz for running some timers/jobs schedule in a DB2 schema (version 11.1, and Driver version 4.24.92), they all fail with the falling stack trace exception:

java.lang.RuntimeException: org.quartz.JobPersistenceException: Couldn't store job: DB2 SQL Error: SQLCODE=-302, SQLSTATE=22001, SQLERRMC=null, DRIVER=4.24.92 [See nested exception: com.ibm.db2.jcc.am.SqlDataException: DB2 SQL Error: SQLCODE=-302, SQLSTATE=22001, SQLERRMC=null, DRIVER=4.24.92]
	at org.jbpm.process.core.timer.impl.QuartzSchedulerService.internalSchedule(QuartzSchedulerService.java:226)
	at org.jbpm.process.core.timer.impl.DelegateSchedulerServiceInterceptor.internalSchedule(DelegateSchedulerServiceInterceptor.java:38)
	at org.jbpm.process.core.timer.impl.QuartzSchedulerService.scheduleJob(QuartzSchedulerService.java:140)
	at org.jbpm.process.core.timer.impl.GlobalTimerService.scheduleJob(GlobalTimerService.java:88)
	at org.jbpm.process.core.timer.impl.RegisteredTimerServiceDelegate.scheduleJob(RegisteredTimerServiceDelegate.java:63)
	at org.jbpm.process.instance.timer.TimerManager.registerTimer(TimerManager.java:128)
	at org.jbpm.process.instance.ProcessRuntimeImpl$RegisterStartTimerAction.initTimer(ProcessRuntimeImpl.java:617)
	at org.jbpm.process.instance.ProcessRuntimeImpl$RegisterStartTimerAction.execute(ProcessRuntimeImpl.java:589)
	at org.drools.core.phreak.SynchronizedBypassPropagationList$1.execute(SynchronizedBypassPropagationList.java:37)
	at org.drools.core.common.DefaultAgenda.executeTask(DefaultAgenda.java:1198)
	at org.drools.core.phreak.SynchronizedBypassPropagationList.addEntry(SynchronizedBypassPropagationList.java:32)
	at org.drools.core.common.DefaultAgenda.addPropagation(DefaultAgenda.java:1304)
	at org.drools.core.impl.StatefulKnowledgeSessionImpl.addPropagation(StatefulKnowledgeSessionImpl.java:2071)
	at org.drools.core.impl.StatefulKnowledgeSessionImpl.queueWorkingMemoryAction(StatefulKnowledgeSessionImpl.java:1593)
	at org.jbpm.process.instance.ProcessRuntimeImpl.initStartTimers(ProcessRuntimeImpl.java:115)
	at org.jbpm.process.instance.ProcessRuntimeImpl.<init>(ProcessRuntimeImpl.java:133)
	at org.jbpm.process.instance.ProcessRuntimeFactoryServiceImpl.newProcessRuntime(ProcessRuntimeFactoryServiceImpl.java:26)
	at org.jbpm.process.instance.ProcessRuntimeFactoryServiceImpl.newProcessRuntime(ProcessRuntimeFactoryServiceImpl.java:23)
	at org.drools.core.runtime.process.ProcessRuntimeFactory.newProcessRuntime(ProcessRuntimeFactory.java:39)
	at org.drools.core.impl.StatefulKnowledgeSessionImpl.createProcessRuntime(StatefulKnowledgeSessionImpl.java:457)
	at org.drools.core.impl.StatefulKnowledgeSessionImpl.getProcessRuntime(StatefulKnowledgeSessionImpl.java:468)
	at org.drools.core.impl.StatefulKnowledgeSessionImpl.addEventListener(StatefulKnowledgeSessionImpl.java:480)
	at org.drools.core.command.runtime.AddEventListenerCommand.execute(AddEventListenerCommand.java:56)
	at org.drools.core.command.runtime.AddEventListenerCommand.execute(AddEventListenerCommand.java:27)
	at org.drools.core.fluent.impl.PseudoClockRunner.executeBatch(PseudoClockRunner.java:102)
	at org.drools.core.fluent.impl.PseudoClockRunner.executeBatches(PseudoClockRunner.java:69)
	at org.drools.core.fluent.impl.PseudoClockRunner.execute(PseudoClockRunner.java:61)
	at org.drools.core.fluent.impl.PseudoClockRunner.execute(PseudoClockRunner.java:39)
	at org.drools.core.command.impl.AbstractInterceptor.executeNext(AbstractInterceptor.java:39)
	at org.drools.persistence.PersistableRunner$TransactionInterceptor.execute(PersistableRunner.java:597)
	at org.drools.persistence.PersistableRunner$TransactionInterceptor.execute(PersistableRunner.java:563)
	at org.drools.core.command.impl.AbstractInterceptor.executeNext(AbstractInterceptor.java:39)
	at org.drools.persistence.jpa.OptimisticLockRetryInterceptor.internalExecute(OptimisticLockRetryInterceptor.java:102)
	at org.drools.persistence.jpa.OptimisticLockRetryInterceptor.execute(OptimisticLockRetryInterceptor.java:83)
	at org.drools.persistence.jpa.OptimisticLockRetryInterceptor.execute(OptimisticLockRetryInterceptor.java:44)
	at org.drools.core.command.impl.AbstractInterceptor.executeNext(AbstractInterceptor.java:39)
	at org.drools.persistence.jta.TransactionLockInterceptor.execute(TransactionLockInterceptor.java:73)
	at org.drools.persistence.jta.TransactionLockInterceptor.execute(TransactionLockInterceptor.java:45)
	at org.drools.core.command.impl.AbstractInterceptor.executeNext(AbstractInterceptor.java:39)
	at org.jbpm.runtime.manager.impl.error.ExecutionErrorHandlerInterceptor.internalExecute(ExecutionErrorHandlerInterceptor.java:66)
	at org.jbpm.runtime.manager.impl.error.ExecutionErrorHandlerInterceptor.execute(ExecutionErrorHandlerInterceptor.java:52)
	at org.jbpm.runtime.manager.impl.error.ExecutionErrorHandlerInterceptor.execute(ExecutionErrorHandlerInterceptor.java:29)
	at org.drools.persistence.PersistableRunner.execute(PersistableRunner.java:398)
	at org.drools.persistence.PersistableRunner.execute(PersistableRunner.java:66)
	at org.drools.core.runtime.InternalLocalRunner.execute(InternalLocalRunner.java:37)
	at org.drools.core.runtime.InternalLocalRunner.execute(InternalLocalRunner.java:41)
	at org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession.addEventListener(CommandBasedStatefulKnowledgeSession.java:495)
	at org.jbpm.runtime.manager.impl.AbstractRuntimeManager.registerItems(AbstractRuntimeManager.java:164)
	at org.jbpm.runtime.manager.impl.SingletonRuntimeManager.init(SingletonRuntimeManager.java:131)
	at org.jbpm.runtime.manager.impl.RuntimeManagerFactoryImpl.newSingletonRuntimeManager(RuntimeManagerFactoryImpl.java:64)
	at org.jbpm.runtime.manager.impl.RuntimeManagerFactoryImpl.newSingletonRuntimeManager(RuntimeManagerFactoryImpl.java:55)
	at org.jbpm.test.functional.timer.GlobalQuartzDBTimerServiceTest.getManager(GlobalQuartzDBTimerServiceTest.java:109)
	at org.jbpm.test.functional.timer.GlobalQuartzDBTimerServiceTest.testContinueTimerWithMisfire(GlobalQuartzDBTimerServiceTest.java:383)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.quartz.JobPersistenceException: Couldn't store job: DB2 SQL Error: SQLCODE=-302, SQLSTATE=22001, SQLERRMC=null, DRIVER=4.24.92
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.storeJob(JobStoreSupport.java:1118)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$2.executeVoid(JobStoreSupport.java:1062)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$VoidTransactionCallback.execute(JobStoreSupport.java:3719)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$VoidTransactionCallback.execute(JobStoreSupport.java:3717)
	at org.quartz.impl.jdbcjobstore.JobStoreCMT.executeInLock(JobStoreCMT.java:245)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.storeJobAndTrigger(JobStoreSupport.java:1058)
	at org.quartz.core.QuartzScheduler.scheduleJob(QuartzScheduler.java:886)
	at org.quartz.impl.StdScheduler.scheduleJob(StdScheduler.java:249)
	at org.jbpm.process.core.timer.impl.QuartzSchedulerService.internalSchedule(QuartzSchedulerService.java:207)
	... 64 common frames omitted
Caused by: com.ibm.db2.jcc.am.SqlDataException: DB2 SQL Error: SQLCODE=-302, SQLSTATE=22001, SQLERRMC=null, DRIVER=4.24.92
	at com.ibm.db2.jcc.am.b6.a(b6.java:802)
	at com.ibm.db2.jcc.am.b6.a(b6.java:66)
	at com.ibm.db2.jcc.am.b6.a(b6.java:140)
	at com.ibm.db2.jcc.am.k3.b(k3.java:2464)
	at com.ibm.db2.jcc.am.k3.c(k3.java:2445)
	at com.ibm.db2.jcc.t4.ab.n(ab.java:894)
	at com.ibm.db2.jcc.t4.ab.a(ab.java:119)
	at com.ibm.db2.jcc.t4.p.a(p.java:50)
	at com.ibm.db2.jcc.t4.aw.b(aw.java:220)
	at com.ibm.db2.jcc.am.k4.bm(k4.java:3571)
	at com.ibm.db2.jcc.am.k4.a(k4.java:4616)
	at com.ibm.db2.jcc.am.k4.b(k4.java:4154)
	at com.ibm.db2.jcc.am.k4.a(k4.java:4799)
	at com.ibm.db2.jcc.am.k4.b(k4.java:4154)
	at com.ibm.db2.jcc.am.k4.be(k4.java:821)
	at com.ibm.db2.jcc.am.k4.executeUpdate(k4.java:795)
	at org.apache.tomcat.dbcp.dbcp2.DelegatingPreparedStatement.executeUpdate(DelegatingPreparedStatement.java:136)
	at org.apache.tomcat.dbcp.dbcp2.DelegatingPreparedStatement.executeUpdate(DelegatingPreparedStatement.java:136)
	at org.quartz.impl.jdbcjobstore.StdJDBCDelegate.insertJobDetail(StdJDBCDelegate.java:624)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.storeJob(JobStoreSupport.java:1112)
	... 72 common frames omitted

We have noticed the problem was in the db blob columns where length limit was set to 2000. Once these lengths are removed, it all work fine.

Thus, we are requesting to merge our changes into your master branch.

Thanks,
Regards.