### PR TITLE
Introducing SerializationHelper

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/DirectSchedulerFactory.java
+++ b/quartz-core/src/main/java/org/quartz/impl/DirectSchedulerFactory.java
@@ -29,11 +29,13 @@ import org.quartz.core.JobRunShellFactory;
 import org.quartz.core.QuartzScheduler;
 import org.quartz.core.QuartzSchedulerResources;
 import org.quartz.simpl.CascadingClassLoadHelper;
+import org.quartz.simpl.ObjectStreamSerializationImpl;
 import org.quartz.simpl.RAMJobStore;
 import org.quartz.simpl.SimpleThreadPool;
 import org.quartz.spi.ClassLoadHelper;
 import org.quartz.spi.JobStore;
 import org.quartz.spi.SchedulerPlugin;
+import org.quartz.spi.SerializationHelper;
 import org.quartz.spi.ThreadExecutor;
 import org.quartz.spi.ThreadPool;
 import org.slf4j.Logger;
@@ -496,9 +498,12 @@ public class DirectSchedulerFactory implements SchedulerFactory {
         ClassLoadHelper cch = new CascadingClassLoadHelper();
         cch.initialize();
 
+        SerializationHelper sh = new ObjectStreamSerializationImpl();
+        sh.initialize();
+
         SchedulerDetailsSetter.setDetails(jobStore, schedulerName, schedulerInstanceId);
 
-        jobStore.initialize(cch, qs.getSchedulerSignaler());
+        jobStore.initialize(cch, qs.getSchedulerSignaler(), sh);
 
         Scheduler scheduler = new StdScheduler(qs);
 

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/CUBRIDDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/CUBRIDDelegate.java
@@ -59,12 +59,7 @@ public class CUBRIDDelegate extends StdJDBCDelegate {
         if (bytes != null && bytes.length != 0) {
             binaryInput = new ByteArrayInputStream(bytes);
 
-            ObjectInputStream in = new ObjectInputStream(binaryInput);
-            try {
-                obj = in.readObject();
-            } finally {
-                in.close();
-            }
+            obj = serializationHelper.readObject(binaryInput);
         }
 
         return obj;

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/CacheDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/CacheDelegate.java
@@ -79,12 +79,7 @@ public class CacheDelegate extends StdJDBCDelegate {
                     } else if (binaryInput instanceof ByteArrayInputStream && ((ByteArrayInputStream) binaryInput).available() == 0 ) {
                         return null;
                     } else {
-                        ObjectInputStream in = new ObjectInputStream(binaryInput);
-                        try {
-                            return in.readObject();
-                        } finally {
-                            in.close();
-                        }
+                        return serializationHelper.readObject(binaryInput);
                     }
                 }
             } finally {

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/DriverDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/DriverDelegate.java
@@ -34,6 +34,7 @@ import org.quartz.TriggerKey;
 import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.spi.ClassLoadHelper;
 import org.quartz.spi.OperableTrigger;
+import org.quartz.spi.SerializationHelper;
 import org.quartz.utils.Key;
 import org.slf4j.Logger;
 
@@ -72,7 +73,8 @@ public interface DriverDelegate {
      * @param initString of the format: settingName=settingValue|otherSettingName=otherSettingValue|...
      * @throws NoSuchDelegateException
      */
-    public void initialize(Logger logger, String tablePrefix, String schedName, String instanceId, ClassLoadHelper classLoadHelper, boolean useProperties, String initString) throws NoSuchDelegateException;
+    public void initialize(Logger logger, String tablePrefix, String schedName, String instanceId, ClassLoadHelper classLoadHelper, 
+            boolean useProperties, String initString, SerializationHelper serializationHelper) throws NoSuchDelegateException;
 
     //---------------------------------------------------------------------------
     // startup / recovery

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/HSQLDBDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/HSQLDBDelegate.java
@@ -69,12 +69,7 @@ public class HSQLDBDelegate extends StdJDBCDelegate {
         
         Object obj = null;
         
-        ObjectInputStream in = new ObjectInputStream(binaryInput);
-        try {
-            obj = in.readObject();
-        } finally {
-            in.close();
-        }
+        obj = serializationHelper.readObject(binaryInput);
 
         return obj;
     }

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreCMT.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreCMT.java
@@ -25,6 +25,7 @@ import org.quartz.JobPersistenceException;
 import org.quartz.SchedulerConfigException;
 import org.quartz.spi.ClassLoadHelper;
 import org.quartz.spi.SchedulerSignaler;
+import org.quartz.spi.SerializationHelper;
 import org.quartz.utils.DBConnectionManager;
 
 /**
@@ -123,7 +124,7 @@ public class JobStoreCMT extends JobStoreSupport {
 
     @Override
     public void initialize(ClassLoadHelper loadHelper,
-            SchedulerSignaler signaler) throws SchedulerConfigException {
+            SchedulerSignaler signaler, SerializationHelper serializationHelper) throws SchedulerConfigException {
 
         if (nonManagedTxDsName == null) {
             throw new SchedulerConfigException(
@@ -140,7 +141,7 @@ public class JobStoreCMT extends JobStoreSupport {
             setUseDBLocks(true);
         }
 
-        super.initialize(loadHelper, signaler);
+        super.initialize(loadHelper, signaler, serializationHelper);
 
         getLog().info("JobStoreCMT initialized.");
     }

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -55,6 +55,7 @@ import org.quartz.spi.ClassLoadHelper;
 import org.quartz.spi.JobStore;
 import org.quartz.spi.OperableTrigger;
 import org.quartz.spi.SchedulerSignaler;
+import org.quartz.spi.SerializationHelper;
 import org.quartz.spi.ThreadExecutor;
 import org.quartz.spi.TriggerFiredBundle;
 import org.quartz.spi.TriggerFiredResult;
@@ -134,6 +135,8 @@ public abstract class JobStoreSupport implements JobStore, Constants {
     private MisfireHandler misfireHandler = null;
 
     private ClassLoadHelper classLoadHelper;
+    
+    private SerializationHelper serializationHelper;
 
     private SchedulerSignaler schedSignaler;
 
@@ -555,6 +558,10 @@ public abstract class JobStoreSupport implements JobStore, Constants {
         return classLoadHelper;
     }
 
+    protected SerializationHelper getSerializationHelper() {
+        return serializationHelper;
+    }
+
     /**
      * Get whether the threads spawned by this JobStore should be
      * marked as daemon.  Possible threads include the <code>MisfireHandler</code> 
@@ -637,7 +644,7 @@ public abstract class JobStoreSupport implements JobStore, Constants {
      * </p>
      */
     public void initialize(ClassLoadHelper loadHelper,
-            SchedulerSignaler signaler) throws SchedulerConfigException {
+            SchedulerSignaler signaler, SerializationHelper serializationHelper) throws SchedulerConfigException {
 
         if (dsName == null) { 
             throw new SchedulerConfigException("DataSource name not set."); 
@@ -678,6 +685,7 @@ public abstract class JobStoreSupport implements JobStore, Constants {
             }
         }
 
+        this.serializationHelper = serializationHelper;
     }
    
     /**
@@ -3212,7 +3220,8 @@ public abstract class JobStoreSupport implements JobStore, Constants {
 
                     delegate = delegateClass.newInstance();
                     
-                    delegate.initialize(getLog(), tablePrefix, instanceName, instanceId, getClassLoadHelper(), canUseProperties(), getDriverDelegateInitString());
+                    delegate.initialize(getLog(), tablePrefix, instanceName, instanceId, getClassLoadHelper(), 
+                            canUseProperties(), getDriverDelegateInitString(), getSerializationHelper());
                     
                 } catch (InstantiationException e) {
                     throw new NoSuchDelegateException("Couldn't create delegate: "

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreTX.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreTX.java
@@ -23,6 +23,7 @@ import org.quartz.JobPersistenceException;
 import org.quartz.SchedulerConfigException;
 import org.quartz.spi.ClassLoadHelper;
 import org.quartz.spi.SchedulerSignaler;
+import org.quartz.spi.SerializationHelper;
 
 /**
  * <p>
@@ -52,9 +53,9 @@ public class JobStoreTX extends JobStoreSupport {
 
     @Override
     public void initialize(ClassLoadHelper classLoadHelper,
-            SchedulerSignaler schedSignaler) throws SchedulerConfigException {
+            SchedulerSignaler schedSignaler, SerializationHelper serializationHelper) throws SchedulerConfigException {
 
-        super.initialize(classLoadHelper, schedSignaler);
+        super.initialize(classLoadHelper, schedSignaler, serializationHelper);
 
         getLog().info("JobStoreTX initialized.");
     }

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/MSSQLDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/MSSQLDelegate.java
@@ -67,12 +67,7 @@ public class MSSQLDelegate extends StdJDBCDelegate {
 
         Object obj = null;
 
-        ObjectInputStream in = new ObjectInputStream(binaryInput);
-        try {
-            obj = in.readObject();
-        } finally {
-            in.close();
-        }
+        obj = serializationHelper.readObject(binaryInput);
 
         return obj;
     }

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/PointbaseDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/PointbaseDelegate.java
@@ -411,12 +411,7 @@ public class PointbaseDelegate extends StdJDBCDelegate {
         InputStream binaryInput = new ByteArrayInputStream(binaryData);
 
         if (null != binaryInput && binaryInput.available() != 0) {
-            ObjectInputStream in = new ObjectInputStream(binaryInput);
-            try {
-                obj = in.readObject();
-            } finally {
-                in.close();
-            }
+            obj = serializationHelper.readObject(binaryInput);
         }
 
         return obj;

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/PostgreSQLDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/PostgreSQLDelegate.java
@@ -68,12 +68,7 @@ public class PostgreSQLDelegate extends StdJDBCDelegate {
         if(bytes != null && bytes.length != 0) {
             binaryInput = new ByteArrayInputStream(bytes);
         
-            ObjectInputStream in = new ObjectInputStream(binaryInput);
-            try {
-                obj = in.readObject();
-            } finally {
-                in.close();
-            }
+            obj = serializationHelper.readObject(binaryInput);
 
         }
         

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/SybaseDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/SybaseDelegate.java
@@ -71,12 +71,7 @@ public class SybaseDelegate extends StdJDBCDelegate {
 
         Object obj = null;
 
-        ObjectInputStream in = new ObjectInputStream(binaryInput);
-        try {
-            obj = in.readObject();
-        } finally {
-            in.close();
-        }
+        obj = serializationHelper.readObject(binaryInput);
 
         return obj;
     }

--- a/quartz-core/src/main/java/org/quartz/simpl/ObjectStreamSerializationImpl.java
+++ b/quartz-core/src/main/java/org/quartz/simpl/ObjectStreamSerializationImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Terracotta, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.quartz.simpl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.quartz.Trigger;
+import org.quartz.spi.SerializationHelper;
+
+
+public class ObjectStreamSerializationImpl implements SerializationHelper {
+
+    @Override
+    public void initialize() {
+
+    }
+
+    @Override
+    public Object readObject(InputStream binaryInput) throws IOException, ClassNotFoundException{
+        Object obj = null;
+        ObjectInputStream in = new ObjectInputStream(binaryInput);
+        try {
+            obj = in.readObject();
+        } finally {
+            in.close();
+        }
+        return obj;
+    }
+
+    @Override
+    public void outputObject(Object obj, ByteArrayOutputStream baos) throws IOException{
+        ObjectOutputStream out = new ObjectOutputStream(baos);
+        out.writeObject(obj);
+        out.flush();
+    }
+
+    @Override
+    public void outputTrigger(Trigger trigger, ByteArrayOutputStream baos) throws IOException {
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(trigger);
+        oos.close();
+    }
+    
+}

--- a/quartz-core/src/main/java/org/quartz/simpl/RAMJobStore.java
+++ b/quartz-core/src/main/java/org/quartz/simpl/RAMJobStore.java
@@ -58,6 +58,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.quartz.impl.matchers.EverythingMatcher.allTriggers;
+import org.quartz.spi.SerializationHelper;
 
 /**
  * <p>
@@ -148,7 +149,7 @@ public class RAMJobStore implements JobStore {
      * used, in order to give the it a chance to initialize.
      * </p>
      */
-    public void initialize(ClassLoadHelper loadHelper, SchedulerSignaler schedSignaler) {
+    public void initialize(ClassLoadHelper loadHelper, SchedulerSignaler schedSignaler, SerializationHelper serializationHelper) {
 
         this.signaler = schedSignaler;
 

--- a/quartz-core/src/main/java/org/quartz/spi/JobStore.java
+++ b/quartz-core/src/main/java/org/quartz/spi/JobStore.java
@@ -72,7 +72,7 @@ public interface JobStore {
      * Called by the QuartzScheduler before the <code>JobStore</code> is
      * used, in order to give the it a chance to initialize.
      */
-    void initialize(ClassLoadHelper loadHelper, SchedulerSignaler signaler) 
+    void initialize(ClassLoadHelper loadHelper, SchedulerSignaler signaler, SerializationHelper serializationHelper) 
         throws SchedulerConfigException;
 
     /**

--- a/quartz-core/src/main/java/org/quartz/spi/SerializationHelper.java
+++ b/quartz-core/src/main/java/org/quartz/spi/SerializationHelper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Terracotta, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.quartz.spi;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.quartz.Trigger;
+
+/**
+ *
+ * @author KZ
+ */
+public interface SerializationHelper {
+    
+    public void initialize();
+    
+    public Object readObject(InputStream binaryInput) throws IOException, ClassNotFoundException;
+    
+    public void outputObject(Object object, ByteArrayOutputStream output) throws IOException;
+    
+    public void outputTrigger(Trigger trigger, ByteArrayOutputStream output) throws IOException;
+    
+}

--- a/quartz-core/src/test/java/org/quartz/AbstractJobStoreTest.java
+++ b/quartz-core/src/test/java/org/quartz/AbstractJobStoreTest.java
@@ -34,6 +34,7 @@ import org.quartz.spi.*;
 import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import org.quartz.simpl.ObjectStreamSerializationImpl;
 
 /**
  * Unit test for JobStores.  These tests were submitted by Johannes Zillmann
@@ -50,8 +51,11 @@ public abstract class AbstractJobStoreTest extends TestCase {
         this.fSignaler = new SampleSignaler();
         ClassLoadHelper loadHelper = new CascadingClassLoadHelper();
         loadHelper.initialize();
+        SerializationHelper serializationHelper = new ObjectStreamSerializationImpl();
+        serializationHelper.initialize();
+        
         this.fJobStore = createJobStore("AbstractJobStoreTest");
-        this.fJobStore.initialize(loadHelper, this.fSignaler);
+        this.fJobStore.initialize(loadHelper, this.fSignaler, serializationHelper);
         this.fJobStore.schedulerStarted();
 
         this.fJobDetail = new JobDetailImpl("job1", "jobGroup1", MyJob.class);
@@ -310,9 +314,11 @@ public abstract class AbstractJobStoreTest extends TestCase {
         SchedulerSignaler schedSignaler = new SampleSignaler();
         ClassLoadHelper loadHelper = new CascadingClassLoadHelper();
         loadHelper.initialize();
-
+        SerializationHelper serializationHelper = new ObjectStreamSerializationImpl();
+        serializationHelper.initialize();
+        
         JobStore store = createJobStore("testStoreAndRetrieveJobs");
-        store.initialize(loadHelper, schedSignaler);
+        store.initialize(loadHelper, schedSignaler, serializationHelper);
 		
 		// Store jobs.
 		for (int i=0; i < 10; i++) {
@@ -336,9 +342,11 @@ public abstract class AbstractJobStoreTest extends TestCase {
         SchedulerSignaler schedSignaler = new SampleSignaler();
         ClassLoadHelper loadHelper = new CascadingClassLoadHelper();
         loadHelper.initialize();
-
+        SerializationHelper serializationHelper = new ObjectStreamSerializationImpl();
+        serializationHelper.initialize();
+        
         JobStore store = createJobStore("testStoreAndRetriveTriggers");
-        store.initialize(loadHelper, schedSignaler);
+        store.initialize(loadHelper, schedSignaler, serializationHelper);
 		
 		// Store jobs and triggers.
 		for (int i=0; i < 10; i++) {
@@ -369,9 +377,11 @@ public abstract class AbstractJobStoreTest extends TestCase {
         SchedulerSignaler schedSignaler = new SampleSignaler();
         ClassLoadHelper loadHelper = new CascadingClassLoadHelper();
         loadHelper.initialize();
+        SerializationHelper serializationHelper = new ObjectStreamSerializationImpl();
+        serializationHelper.initialize();
 
         JobStore store = createJobStore("testMatchers");
-        store.initialize(loadHelper, schedSignaler);
+        store.initialize(loadHelper, schedSignaler, serializationHelper);
 
         JobDetail job = JobBuilder.newJob(MyJob.class).withIdentity("job1", "aaabbbccc").build();
         store.storeJob(job, true);
@@ -451,9 +461,11 @@ public abstract class AbstractJobStoreTest extends TestCase {
 		SchedulerSignaler schedSignaler = new SampleSignaler();
 		ClassLoadHelper loadHelper = new CascadingClassLoadHelper();
 		loadHelper.initialize();
-		
+		SerializationHelper serializationHelper = new ObjectStreamSerializationImpl();
+        serializationHelper.initialize();
+        
         JobStore store = createJobStore("testAcquireTriggers");
-		store.initialize(loadHelper, schedSignaler);
+		store.initialize(loadHelper, schedSignaler, serializationHelper);
 		
 		// Setup: Store jobs and triggers.
 		long MIN = 60 * 1000L;
@@ -490,9 +502,11 @@ public abstract class AbstractJobStoreTest extends TestCase {
 		SchedulerSignaler schedSignaler = new SampleSignaler();
 		ClassLoadHelper loadHelper = new CascadingClassLoadHelper();
 		loadHelper.initialize();
-		
+		SerializationHelper serializationHelper = new ObjectStreamSerializationImpl();
+        serializationHelper.initialize();
+        
         JobStore store = createJobStore("testAcquireTriggersInBatch");
-		store.initialize(loadHelper, schedSignaler);
+		store.initialize(loadHelper, schedSignaler, serializationHelper);
 		
 		// Setup: Store jobs and triggers.
 		long MIN = 60 * 1000L;

--- a/quartz-core/src/test/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegateTest.java
+++ b/quartz-core/src/test/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegateTest.java
@@ -39,12 +39,14 @@ import org.quartz.JobDataMap;
 import org.quartz.simpl.SimpleClassLoadHelper;
 
 import junit.framework.TestCase;
+import org.quartz.simpl.ObjectStreamSerializationImpl;
 
 public class StdJDBCDelegateTest extends TestCase {
 
     public void testSerializeJobData() throws IOException, NoSuchDelegateException {
         StdJDBCDelegate delegate = new StdJDBCDelegate();
-        delegate.initialize(LoggerFactory.getLogger(getClass()), "QRTZ_", "TESTSCHED", "INSTANCE", new SimpleClassLoadHelper(), false, "");
+        delegate.initialize(LoggerFactory.getLogger(getClass()), "QRTZ_", "TESTSCHED", "INSTANCE", new SimpleClassLoadHelper(), 
+                false, "", new ObjectStreamSerializationImpl());
         
         JobDataMap jdm = new JobDataMap();
         delegate.serializeJobData(jdm).close();
@@ -68,7 +70,8 @@ public class StdJDBCDelegateTest extends TestCase {
 
     public void testSelectBlobTriggerWithNoBlobContent() throws JobPersistenceException, SQLException, IOException, ClassNotFoundException {
         StdJDBCDelegate jdbcDelegate = new StdJDBCDelegate();
-        jdbcDelegate.initialize(LoggerFactory.getLogger(getClass()), "QRTZ_", "TESTSCHED", "INSTANCE", new SimpleClassLoadHelper(), false, "");
+        jdbcDelegate.initialize(LoggerFactory.getLogger(getClass()), "QRTZ_", "TESTSCHED", "INSTANCE", new SimpleClassLoadHelper(), 
+                false, "", new ObjectStreamSerializationImpl());
 
         Connection conn = mock(Connection.class);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
@@ -92,7 +95,8 @@ public class StdJDBCDelegateTest extends TestCase {
         when(persistenceDelegate.loadExtendedTriggerProperties(any(Connection.class), any(TriggerKey.class))).thenThrow(exception);
 
         StdJDBCDelegate jdbcDelegate = new TestStdJDBCDelegate(persistenceDelegate);
-        jdbcDelegate.initialize(LoggerFactory.getLogger(getClass()), "QRTZ_", "TESTSCHED", "INSTANCE", new SimpleClassLoadHelper(), false, "");
+        jdbcDelegate.initialize(LoggerFactory.getLogger(getClass()), "QRTZ_", "TESTSCHED", "INSTANCE", new SimpleClassLoadHelper(), 
+                false, "", new ObjectStreamSerializationImpl());
 
         Connection conn = mock(Connection.class);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
@@ -120,7 +124,8 @@ public class StdJDBCDelegateTest extends TestCase {
         when(persistenceDelegate.loadExtendedTriggerProperties(any(Connection.class), any(TriggerKey.class))).thenThrow(new IllegalStateException());
 
         StdJDBCDelegate jdbcDelegate = new TestStdJDBCDelegate(persistenceDelegate);
-        jdbcDelegate.initialize(LoggerFactory.getLogger(getClass()), "QRTZ_", "TESTSCHED", "INSTANCE", new SimpleClassLoadHelper(), false, "");
+        jdbcDelegate.initialize(LoggerFactory.getLogger(getClass()), "QRTZ_", "TESTSCHED", "INSTANCE", new SimpleClassLoadHelper(), 
+                false, "", new ObjectStreamSerializationImpl());
 
         Connection conn = mock(Connection.class);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);


### PR DESCRIPTION
Hi!

I've read in Quartz3 ideas about using JSON or any other text based serialization methods instead of binary objects. 

I would like to advise using a SerializationHelper interface and an ObjectStreamSerializationImpl implementation, which does exactly the base functionality. A different SerializationHelper class can be implemented and configured via config parameter "org.quartz.scheduler.serializationHelper.class" which uses JSON, or any other notation.