### PR TITLE
Corrected inconsistent listener notification for resumeAll() and pauseAll()

### DIFF
--- a/quartz-core/src/main/java/org/quartz/core/QuartzScheduler.java
+++ b/quartz-core/src/main/java/org/quartz/core/QuartzScheduler.java
@@ -1407,7 +1407,7 @@ public class QuartzScheduler implements RemotableQuartzScheduler {
 
         resources.getJobStore().resumeAll();
         notifySchedulerThread(0L);
-        notifySchedulerListenersResumedTrigger(null);
+        notifySchedulerListenersResumedTriggers(null);
     }
 
     /**


### PR DESCRIPTION
resumeAll() is invoking SchedulerListenerSupport.triggerResumed(TriggerKey triggerKey) with triggerKey as null

But as documentation, resumeAll() is equivalent of calling resumeTriggerGroup(group)on every group, not on a single trigger
So changed it to invoke SchedulerListenerSupport.triggersResumed(String triggerGroup) also to be consistent with pauseAll() method