### PR TITLE
Add workflow support

### DIFF
--- a/quartz-core/src/main/java/org/quartz/JobListener.java
+++ b/quartz-core/src/main/java/org/quartz/JobListener.java
@@ -64,7 +64,7 @@ public interface JobListener {
      * 
      * @see #jobExecutionVetoed(JobExecutionContext)
      */
-    void jobToBeExecuted(JobExecutionContext context);
+    void jobToBeExecuted(JobExecutionContext context) throws SchedulerException;
 
     /**
      * <p>
@@ -76,7 +76,7 @@ public interface JobListener {
      * 
      * @see #jobToBeExecuted(JobExecutionContext)
      */
-    void jobExecutionVetoed(JobExecutionContext context);
+    void jobExecutionVetoed(JobExecutionContext context) throws SchedulerException;
 
     
     /**
@@ -87,6 +87,6 @@ public interface JobListener {
      * </p>
      */
     void jobWasExecuted(JobExecutionContext context,
-            JobExecutionException jobException);
+            JobExecutionException jobException) throws SchedulerException;
 
 }

--- a/quartz-core/src/main/java/org/quartz/listeners/BroadcastJobListener.java
+++ b/quartz-core/src/main/java/org/quartz/listeners/BroadcastJobListener.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.JobListener;
+import org.quartz.SchedulerException;
 
 /**
  * Holds a List of references to JobListener instances and broadcasts all
@@ -98,7 +99,7 @@ public class BroadcastJobListener implements JobListener {
         return java.util.Collections.unmodifiableList(listeners);
     }
 
-    public void jobToBeExecuted(JobExecutionContext context) {
+    public void jobToBeExecuted(JobExecutionContext context) throws SchedulerException {
 
         Iterator<JobListener> itr = listeners.iterator();
         while(itr.hasNext()) {
@@ -107,7 +108,7 @@ public class BroadcastJobListener implements JobListener {
         }
     }
 
-    public void jobExecutionVetoed(JobExecutionContext context) {
+    public void jobExecutionVetoed(JobExecutionContext context) throws SchedulerException {
 
         Iterator<JobListener> itr = listeners.iterator();
         while(itr.hasNext()) {
@@ -116,7 +117,7 @@ public class BroadcastJobListener implements JobListener {
         }
     }
 
-    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) throws SchedulerException {
 
         Iterator<JobListener> itr = listeners.iterator();
         while(itr.hasNext()) {

--- a/quartz-core/src/main/java/org/quartz/workflow/CombinedCondition.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/CombinedCondition.java
@@ -1,0 +1,44 @@
+/*
+ * Created on Jan 28, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+import org.quartz.impl.matchers.GroupMatcher;
+
+public class CombinedCondition implements WorkflowCondition{
+    private static final long serialVersionUID = WorkflowCondition.serialVersionUID;
+    private final List<WorkflowCondition> conditions;
+
+    public CombinedCondition() {
+        conditions = new ArrayList<>();
+    }
+    
+    @Override
+    public boolean canStartJobs(Schedulers schedulers) throws SchedulerException {
+        for(WorkflowCondition condition : conditions)
+            if(! condition.canStartJobs(schedulers))
+                return false;
+        return true;
+    }
+
+    public CombinedCondition with(String schedulerName, GroupMatcher<JobKey> groupMatcher) {
+        return with(new GroupJobsDoneCondition(schedulerName, groupMatcher));
+    }
+
+
+    public CombinedCondition with(String schedulerName, JobKey jobKey) {
+        return with (new SingleJobDoneCondition(schedulerName, jobKey));
+    }
+    
+    public CombinedCondition with(WorkflowCondition condition) {
+        conditions.add(condition);
+        return this;
+    }
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/CombinedRule.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/CombinedRule.java
@@ -1,0 +1,41 @@
+/*
+ * Created on Jan 28, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import java.util.ArrayList;
+
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+import org.quartz.impl.matchers.GroupMatcher;
+
+public class CombinedRule implements WorkflowRule{
+    private static final long serialVersionUID = WorkflowRule.serialVersionUID;
+    private final ArrayList<WorkflowRule> rules;
+
+    public CombinedRule() {
+        super();
+        this.rules = new ArrayList<>();
+    }
+
+    @Override
+    public void apply(Schedulers schedulers) throws SchedulerException {
+        for(WorkflowRule rule : rules)
+            rule.apply(schedulers);
+    }
+
+    public CombinedRule with(WorkflowRule rule) {
+        rules.add(rule);
+        return this;
+    }
+
+    public CombinedRule with(String schedulerName, GroupMatcher<JobKey> groupMatcher) {
+       return with(new GroupRule(schedulerName, groupMatcher));
+    }
+
+    public CombinedRule with(String schedulerName, JobKey jobKey) {
+        return with(new SingleJobRule(schedulerName, jobKey));
+    }
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/ConditionalRule.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/ConditionalRule.java
@@ -1,0 +1,38 @@
+/*
+ * Created on Jan 27, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+import org.quartz.impl.matchers.GroupMatcher;
+
+public class ConditionalRule implements WorkflowRule {
+    
+    private static final long serialVersionUID = WorkflowRule.serialVersionUID;
+    private final WorkflowCondition condition;
+    private final WorkflowRule rule;
+
+    
+    public ConditionalRule(WorkflowCondition condition, WorkflowRule rule) {
+        this.condition = condition;
+        this.rule = rule;
+    }
+     
+    public ConditionalRule(GroupMatcher<JobKey> currentJobGroupMatcher,JobKey followingJobKey) {
+        this(new GroupJobsDoneCondition(currentJobGroupMatcher), new SingleJobRule(followingJobKey));
+    }
+     
+    public ConditionalRule(GroupMatcher<JobKey> currentJobGroupMatcher,GroupMatcher<JobKey> followingJobMatcher) {
+        this(new GroupJobsDoneCondition(currentJobGroupMatcher), new GroupRule(followingJobMatcher));
+    }
+     
+    @Override
+    public void apply(Schedulers schedulers) throws SchedulerException{
+        if(condition.canStartJobs(schedulers))
+            rule.apply(schedulers);
+    }
+
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/FollowingJobStarter.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/FollowingJobStarter.java
@@ -37,12 +37,8 @@ class FollowingJobStarter implements JobListener{
     public void jobExecutionVetoed(JobExecutionContext context) {/**/}
 
     @Override
-    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
-        try {
-            startFollowingJobs(context);
-        } catch (SchedulerException e) {
-            throw new RuntimeException(e);
-        }
+    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) throws SchedulerException {
+        startFollowingJobs(context);
     }
     
     private void startFollowingJobs(JobExecutionContext context) throws SchedulerException {

--- a/quartz-core/src/main/java/org/quartz/workflow/FollowingJobStarter.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/FollowingJobStarter.java
@@ -38,7 +38,7 @@ class FollowingJobStarter implements JobListener{
     private void startFollowingJobs(JobExecutionContext context) throws SchedulerException {
         final JobDetail jobDetail = context.getJobDetail();
         final JobDataMap data = jobDetail.getJobDataMap();
-        WorkflowRule followingJobStarter = (WorkflowRule) data.get(Workflow.FOLLOWING_JOB_STARTER);
+        WorkflowRule followingJobStarter = (WorkflowRule) data.get(Workflow.WORKFLOW_RULE);
         if(followingJobStarter == null)
             return;
         final Scheduler scheduler = context.getScheduler();

--- a/quartz-core/src/main/java/org/quartz/workflow/FollowingJobStarter.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/FollowingJobStarter.java
@@ -1,0 +1,51 @@
+/*
+ * Created on Jan 26, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobListener;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+class FollowingJobStarter implements JobListener{
+    
+    static final String LISTENER_NAME = FollowingJobStarter.class.getName();
+    static final FollowingJobStarter INSTANCE = new FollowingJobStarter();
+
+    @Override
+    public String getName() {
+        return LISTENER_NAME;
+    }
+
+    @Override
+    public void jobToBeExecuted(JobExecutionContext context) {/**/}
+
+    @Override
+    public void jobExecutionVetoed(JobExecutionContext context) {/**/}
+
+    @Override
+    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+        try {
+            startFollowingJobs(context);
+        } catch (SchedulerException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    private void startFollowingJobs(JobExecutionContext context) throws SchedulerException {
+        final JobDetail jobDetail = context.getJobDetail();
+        final JobDataMap data = jobDetail.getJobDataMap();
+        WorkflowRule followingJobStarter = (WorkflowRule) data.get(Workflow.FOLLOWING_JOB_STARTER);
+        if(followingJobStarter == null)
+            return;
+        final Scheduler scheduler = context.getScheduler();
+        scheduler.deleteJob(jobDetail.getKey());
+        followingJobStarter.startJobsIfReady(scheduler);
+    }
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/FollowingJobStarter.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/FollowingJobStarter.java
@@ -30,12 +30,9 @@ class FollowingJobStarter implements JobListener{
     public void jobExecutionVetoed(JobExecutionContext context) {/**/}
 
     @Override
-    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
-        try {
-            startFollowingJobs(context);
-        } catch (SchedulerException e) {
-            throw new RuntimeException(e);
-        }
+    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) 
+            throws SchedulerException {
+        startFollowingJobs(context);
     }
     
     private void startFollowingJobs(JobExecutionContext context) throws SchedulerException {

--- a/quartz-core/src/main/java/org/quartz/workflow/GroupJobsDoneCondition.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/GroupJobsDoneCondition.java
@@ -1,0 +1,34 @@
+/*
+ * Created on Jan 28, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.impl.matchers.GroupMatcher;
+
+public class GroupJobsDoneCondition implements WorkflowCondition {
+    private static final long serialVersionUID = WorkflowCondition.serialVersionUID;
+    private final String schedulerName;
+    private final GroupMatcher<JobKey> currentJobGroupMatcher;
+
+    public GroupJobsDoneCondition(GroupMatcher<JobKey> currentJobGroupMatcher) {
+        this(null, currentJobGroupMatcher);
+    }
+
+    public GroupJobsDoneCondition(String schedulerName, GroupMatcher<JobKey> currentJobGroupMatcher) {
+        super();
+        this.currentJobGroupMatcher = currentJobGroupMatcher;
+        this.schedulerName = schedulerName;
+    }
+
+    @Override
+    public boolean canStartJobs(Schedulers schedulers) throws SchedulerException {
+        final Scheduler conditionScheduler = schedulers.byNameOrDefault(schedulerName);
+        final boolean ready = conditionScheduler.getJobKeys(currentJobGroupMatcher).isEmpty();
+        return ready;
+    }
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/GroupRule.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/GroupRule.java
@@ -1,0 +1,40 @@
+/*
+ * Created on Jan 27, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import java.util.Set;
+
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.impl.matchers.GroupMatcher;
+
+public class GroupRule extends WorkflowRule{
+    private static final long serialVersionUID = WorkflowRule.serialVersionUID;
+
+    private final GroupMatcher<JobKey> followingJobMatcher;
+
+    public GroupRule(GroupMatcher<JobKey> currentJobGroupMatcher, GroupMatcher<JobKey> followingJobMatcher) {
+        super(currentJobGroupMatcher);
+        this.followingJobMatcher = followingJobMatcher;
+    }
+    
+    public GroupRule(GroupMatcher<JobKey> followingJobMatcher) {
+        super();
+        this.followingJobMatcher = followingJobMatcher;
+    }
+    
+    @Override
+    void startJobs(Scheduler scheduler) throws SchedulerException{
+        startJobs(scheduler, followingJobMatcher);
+    }
+
+    void startJobs(Scheduler scheduler, GroupMatcher<JobKey> jobMatcher) throws SchedulerException{
+        final Set<JobKey> jobKeys = scheduler.getJobKeys(jobMatcher);
+        for(JobKey key : jobKeys)
+            startJob(scheduler, key);
+    }
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/JobStarter.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/JobStarter.java
@@ -1,0 +1,38 @@
+/*
+ * Created on Jan 28, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import org.quartz.JobKey;
+import org.quartz.JobPersistenceException;
+import org.quartz.ObjectAlreadyExistsException;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+
+class JobStarter {
+    static void startJob(final Scheduler scheduler, JobKey job, int triggerPriority)
+            throws SchedulerException {
+        TriggerKey triggerKey = new TriggerKey(job.getName(), 
+                job.getGroup() + WorkflowRule.TRIGGER_GROUP_UUID);
+        try {
+            scheduler.scheduleJob(TriggerBuilder.newTrigger()
+                    .withIdentity(triggerKey)
+                    .withPriority(triggerPriority)
+                    .forJob(job).startNow().build());
+        } catch (ObjectAlreadyExistsException e) {
+            ignoreRaceConditions();
+        } catch (JobPersistenceException e) {
+            if(scheduler.checkExists(job))
+                throw e;
+            else
+                ignoreRaceConditions();
+        }
+    }
+
+    static void ignoreRaceConditions() {/**/}
+
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/Schedulers.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/Schedulers.java
@@ -1,0 +1,13 @@
+/*
+ * Created on Jan 28, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+interface Schedulers {
+    Scheduler byNameOrDefault(String schedulerName) throws SchedulerException;
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/SingleJobDoneCondition.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/SingleJobDoneCondition.java
@@ -1,0 +1,33 @@
+/*
+ * Created on Jan 28, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+public class SingleJobDoneCondition implements WorkflowCondition {
+    private static final long serialVersionUID = WorkflowCondition.serialVersionUID;
+    private final String schedulerName;
+    private final JobKey jobKey;
+
+    public SingleJobDoneCondition(JobKey jobKey) {
+        this(null, jobKey);
+    }
+
+    public SingleJobDoneCondition(String schedulerName, JobKey jobKey) {
+        super();
+        this.jobKey = jobKey;
+        this.schedulerName = schedulerName;
+    }
+
+    @Override
+    public boolean canStartJobs(Schedulers schedulers) throws SchedulerException {
+        final Scheduler conditionScheduler = schedulers.byNameOrDefault(schedulerName);
+        final boolean ready = ! conditionScheduler.checkExists(jobKey);
+        return ready;
+    }
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/SingleJobRule.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/SingleJobRule.java
@@ -1,0 +1,33 @@
+/*
+ * Created on Jan 27, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.impl.matchers.GroupMatcher;
+
+public class SingleJobRule extends WorkflowRule {
+    
+    private static final long serialVersionUID = WorkflowRule.serialVersionUID;
+    
+    private final JobKey followingJobKey;
+    
+    public SingleJobRule(GroupMatcher<JobKey> currentJobGroupMatcher,JobKey followingJobKey) {
+        super(currentJobGroupMatcher);
+        this.followingJobKey = followingJobKey;
+    }
+    
+    public SingleJobRule(JobKey followingJobKey) {
+        super();
+        this.followingJobKey = followingJobKey;
+    }
+     
+    @Override
+    void startJobs(Scheduler scheduler) throws SchedulerException{
+        startJob(scheduler, followingJobKey);
+    }
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/SingleJobRule.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/SingleJobRule.java
@@ -8,26 +8,33 @@ package org.quartz.workflow;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
-import org.quartz.impl.matchers.GroupMatcher;
+import org.quartz.Trigger;
 
-public class SingleJobRule extends WorkflowRule {
+public class SingleJobRule implements WorkflowRule {
     
     private static final long serialVersionUID = WorkflowRule.serialVersionUID;
     
+    private final String schedulerName;
     private final JobKey followingJobKey;
-    
-    public SingleJobRule(GroupMatcher<JobKey> currentJobGroupMatcher,JobKey followingJobKey) {
-        super(currentJobGroupMatcher);
-        this.followingJobKey = followingJobKey;
-    }
+    private int triggerPriority = Trigger.DEFAULT_PRIORITY;
     
     public SingleJobRule(JobKey followingJobKey) {
-        super();
+        this(null, followingJobKey);
+    }
+   
+    public SingleJobRule(String schedulerName, JobKey followingJobKey) {
+        this.schedulerName = schedulerName;
         this.followingJobKey = followingJobKey;
     }
-     
+    
+    public SingleJobRule setTriggerPriority(int priority) {
+        this.triggerPriority = priority;
+        return this;
+    }
+
     @Override
-    void startJobs(Scheduler scheduler) throws SchedulerException{
-        startJob(scheduler, followingJobKey);
+    public void apply(Schedulers schedulers) throws SchedulerException{
+        final Scheduler scheduler = schedulers.byNameOrDefault(schedulerName);
+        JobStarter.startJob(scheduler, followingJobKey, triggerPriority);
     }
 }

--- a/quartz-core/src/main/java/org/quartz/workflow/Workflow.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/Workflow.java
@@ -1,0 +1,55 @@
+/*
+ * Created on Jan 26, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.ListenerManager;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.impl.matchers.EverythingMatcher;
+import org.quartz.impl.matchers.GroupMatcher;
+
+public class Workflow {
+    
+    static final String FOLLOWING_JOB_STARTER = FollowingJobStarter.class.getName();
+    
+    private final Scheduler scheduler;
+
+    public Workflow(Scheduler scheduler){
+        super();
+        this.scheduler = scheduler;
+        try {
+            ListenerManager listenerManager = scheduler.getListenerManager();
+            if (listenerManager.getJobListener(FollowingJobStarter.LISTENER_NAME) == null)
+                listenerManager.addJobListener(FollowingJobStarter.INSTANCE, EverythingMatcher.allJobs());
+        } catch (SchedulerException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public void addJob(JobDetail job, final WorkflowRule workflowRule) throws SchedulerException {
+        final JobDataMap data = job.getJobDataMap();
+        data.put(FOLLOWING_JOB_STARTER, workflowRule);
+        addJob(job);
+    }
+
+    public void addJob(JobDetail job) throws SchedulerException {
+        if(job.isDurable())
+            throw new IllegalArgumentException("Durable jobs are not allowed in workflow");
+        scheduler.addJob(job, false, true);
+    }
+    
+    public void startJobs(GroupMatcher<JobKey> jobMatcher) throws SchedulerException {
+        new GroupRule(jobMatcher).startJobs(scheduler);
+    }
+
+    public void startJob(JobKey job) throws SchedulerException {
+        new SingleJobRule(job).startJobs(scheduler);
+    }
+
+ }

--- a/quartz-core/src/main/java/org/quartz/workflow/Workflow.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/Workflow.java
@@ -1,9 +1,12 @@
 /*
  * Created on Jan 26, 2021
  *
- * author Dimitry Polivaev
+ * author dimitry
  */
 package org.quartz.workflow;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -14,42 +17,66 @@ import org.quartz.SchedulerException;
 import org.quartz.impl.matchers.EverythingMatcher;
 import org.quartz.impl.matchers.GroupMatcher;
 
+/*
+ * Created on Jan 26, 2021
+ *
+ * author Dimitry Polivaev
+ */
 public class Workflow {
     
     static final String WORKFLOW_RULE = WorkflowRule.class.getName();
+    private final Map<String, Scheduler > schedulers;
+    private final FollowingJobStarter starter;
     
-    private final Scheduler scheduler;
-
-    public Workflow(Scheduler scheduler){
+    public Workflow(){
         super();
-        this.scheduler = scheduler;
-        try {
-            ListenerManager listenerManager = scheduler.getListenerManager();
-            if (listenerManager.getJobListener(FollowingJobStarter.LISTENER_NAME) == null)
-                listenerManager.addJobListener(FollowingJobStarter.INSTANCE, EverythingMatcher.allJobs());
-        } catch (SchedulerException e) {
-            throw new IllegalArgumentException(e);
+        this.schedulers = new ConcurrentHashMap<>();
+        starter = new FollowingJobStarter(this::getScheduler);
+    }
+
+    private void register(Scheduler scheduler) throws SchedulerException {
+        final String schedulerName = scheduler.getSchedulerName();
+        ListenerManager listenerManager = scheduler.getListenerManager();
+        if (null ==  this.schedulers.putIfAbsent(schedulerName, scheduler)) {
+            if(listenerManager.getJobListener(starter.getName()) != null)
+                throw new SchedulerException("Scheduler" + schedulerName + " is already registered");
+            listenerManager.addJobListener(starter, EverythingMatcher.allJobs());
         }
     }
-
-    public void addJob(JobDetail job, final WorkflowRule workflowRule) throws SchedulerException {
-        final JobDataMap data = job.getJobDataMap();
-        data.put(WORKFLOW_RULE, workflowRule);
-        addJob(job);
+    
+    public void remove() throws SchedulerException {
+        for(Scheduler scheduler: schedulers.values()) {
+            scheduler.getListenerManager().removeJobListener(starter.getName());
+        }
+        schedulers.clear();
+    }
+    
+    private Scheduler getScheduler(String schedulerName) throws SchedulerException {
+        final Scheduler scheduler = schedulers.get(schedulerName);
+        if(scheduler == null)
+            throw new SchedulerException("Unknown scheduler " +schedulerName);
+        return scheduler;
     }
 
-    public void addJob(JobDetail job) throws SchedulerException {
+    public void addJob(Scheduler scheduler, JobDetail job, final WorkflowRule workflowRule) throws SchedulerException {
+        final JobDataMap data = job.getJobDataMap();
+        data.put(WORKFLOW_RULE, workflowRule);
+        register(scheduler);
+        addJob(scheduler, job);
+    }
+
+    public void addJob(Scheduler scheduler, JobDetail job) throws SchedulerException {
         if(job.isDurable())
             throw new IllegalArgumentException("Durable jobs are not allowed in workflow");
         scheduler.addJob(job, false, true);
     }
     
-    public void startJobs(GroupMatcher<JobKey> jobMatcher) throws SchedulerException {
-        new GroupRule(jobMatcher).startJobs(scheduler);
+    public void startJobs(Scheduler scheduler, GroupMatcher<JobKey> jobMatcher) throws SchedulerException {
+        new GroupRule(jobMatcher).apply(x -> scheduler);
     }
 
-    public void startJob(JobKey job) throws SchedulerException {
-        new SingleJobRule(job).startJobs(scheduler);
+    public void startJob(Scheduler scheduler, JobKey job) throws SchedulerException {
+        new SingleJobRule(job).apply(x -> scheduler);
     }
 
  }

--- a/quartz-core/src/main/java/org/quartz/workflow/Workflow.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/Workflow.java
@@ -61,13 +61,13 @@ public class Workflow {
     public void addJob(Scheduler scheduler, JobDetail job, final WorkflowRule workflowRule) throws SchedulerException {
         final JobDataMap data = job.getJobDataMap();
         data.put(WORKFLOW_RULE, workflowRule);
-        register(scheduler);
         addJob(scheduler, job);
     }
 
     public void addJob(Scheduler scheduler, JobDetail job) throws SchedulerException {
         if(job.isDurable())
             throw new IllegalArgumentException("Durable jobs are not allowed in workflow");
+        register(scheduler);
         scheduler.addJob(job, false, true);
     }
     

--- a/quartz-core/src/main/java/org/quartz/workflow/Workflow.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/Workflow.java
@@ -1,7 +1,7 @@
 /*
  * Created on Jan 26, 2021
  *
- * author dimitry
+ * author Dimitry Polivaev
  */
 package org.quartz.workflow;
 
@@ -16,7 +16,7 @@ import org.quartz.impl.matchers.GroupMatcher;
 
 public class Workflow {
     
-    static final String FOLLOWING_JOB_STARTER = FollowingJobStarter.class.getName();
+    static final String WORKFLOW_RULE = WorkflowRule.class.getName();
     
     private final Scheduler scheduler;
 
@@ -34,7 +34,7 @@ public class Workflow {
 
     public void addJob(JobDetail job, final WorkflowRule workflowRule) throws SchedulerException {
         final JobDataMap data = job.getJobDataMap();
-        data.put(FOLLOWING_JOB_STARTER, workflowRule);
+        data.put(WORKFLOW_RULE, workflowRule);
         addJob(job);
     }
 

--- a/quartz-core/src/main/java/org/quartz/workflow/WorkflowCondition.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/WorkflowCondition.java
@@ -1,0 +1,24 @@
+/*
+ * Created on Jan 28, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import java.io.Serializable;
+
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+import org.quartz.impl.matchers.GroupMatcher;
+
+public interface WorkflowCondition extends Serializable {
+    long serialVersionUID = 2379672576808405507L;
+    boolean canStartJobs(Schedulers schedulers) throws SchedulerException;
+    static CombinedCondition with(String schedulerName, GroupMatcher<JobKey> groupMatcher) {
+        return new CombinedCondition().with(schedulerName, groupMatcher);
+    }
+    static CombinedCondition with(String schedulerName, JobKey key) {
+        return new CombinedCondition().with(schedulerName, key);
+    }
+
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/WorkflowRule.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/WorkflowRule.java
@@ -1,0 +1,69 @@
+/*
+ * Created on Jan 27, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import java.io.Serializable;
+
+import org.quartz.JobKey;
+import org.quartz.JobPersistenceException;
+import org.quartz.ObjectAlreadyExistsException;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.quartz.impl.matchers.GroupMatcher;
+
+abstract public class WorkflowRule implements Serializable{
+    static final long serialVersionUID = 2379672576808405507L;
+    final static String TRIGGER_GROUP_UUID = "/6ec1329e-d962-4dc1-aefa-c8eff7fa9165";
+
+    private final GroupMatcher<JobKey> currentJobGroupMatcher;
+    private int triggerPriority = Trigger.DEFAULT_PRIORITY;
+    
+    WorkflowRule() {
+        this(null);
+    }
+    WorkflowRule(GroupMatcher<JobKey> currentJobGroupMatcher) {
+        super();
+        this.currentJobGroupMatcher = currentJobGroupMatcher;
+    }
+
+    abstract void startJobs(Scheduler scheduler) throws SchedulerException;
+
+    public WorkflowRule setTriggerPriority(int priority) {
+        this.triggerPriority = priority;
+        return this;
+    }
+    
+    void startJobsIfReady(Scheduler scheduler) throws SchedulerException {
+        final boolean ready = currentJobGroupMatcher == null || scheduler.getJobKeys(currentJobGroupMatcher).isEmpty();
+        if(ready)
+            startJobs(scheduler);
+    }
+
+
+    void startJob(final Scheduler scheduler, JobKey job)
+            throws SchedulerException {
+        TriggerKey triggerKey = new TriggerKey(job.getName(), 
+                job.getGroup() + WorkflowRule.TRIGGER_GROUP_UUID);
+        try {
+            scheduler.scheduleJob(TriggerBuilder.newTrigger()
+                    .withIdentity(triggerKey)
+                    .withPriority(triggerPriority)
+                    .forJob(job).startNow().build());
+        } catch (ObjectAlreadyExistsException e) {
+            ignoreRaceConditions();
+        } catch (JobPersistenceException e) {
+            if(scheduler.checkExists(job))
+                throw e;
+            else
+                ignoreRaceConditions();
+        }
+    }
+
+    private void ignoreRaceConditions() {/**/}
+}

--- a/quartz-core/src/main/java/org/quartz/workflow/WorkflowRule.java
+++ b/quartz-core/src/main/java/org/quartz/workflow/WorkflowRule.java
@@ -8,62 +8,17 @@ package org.quartz.workflow;
 import java.io.Serializable;
 
 import org.quartz.JobKey;
-import org.quartz.JobPersistenceException;
-import org.quartz.ObjectAlreadyExistsException;
-import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
-import org.quartz.Trigger;
-import org.quartz.TriggerBuilder;
-import org.quartz.TriggerKey;
 import org.quartz.impl.matchers.GroupMatcher;
 
-abstract public class WorkflowRule implements Serializable{
-    static final long serialVersionUID = 2379672576808405507L;
-    final static String TRIGGER_GROUP_UUID = "/6ec1329e-d962-4dc1-aefa-c8eff7fa9165";
-
-    private final GroupMatcher<JobKey> currentJobGroupMatcher;
-    private int triggerPriority = Trigger.DEFAULT_PRIORITY;
-    
-    WorkflowRule() {
-        this(null);
+public interface WorkflowRule extends Serializable {
+    long serialVersionUID = 2379672576808405507L;
+    String TRIGGER_GROUP_UUID = "/6ec1329e-d962-4dc1-aefa-c8eff7fa9165";
+    void apply(Schedulers schedulers) throws SchedulerException;
+    static CombinedRule with(String schedulerName, GroupMatcher<JobKey> groupMatcher) {
+        return new CombinedRule().with(schedulerName, groupMatcher);
     }
-    WorkflowRule(GroupMatcher<JobKey> currentJobGroupMatcher) {
-        super();
-        this.currentJobGroupMatcher = currentJobGroupMatcher;
+    static CombinedRule with(String schedulerName, JobKey jobKey) {
+        return new CombinedRule().with(schedulerName, jobKey);
     }
-
-    abstract void startJobs(Scheduler scheduler) throws SchedulerException;
-
-    public WorkflowRule setTriggerPriority(int priority) {
-        this.triggerPriority = priority;
-        return this;
-    }
-    
-    void startJobsIfReady(Scheduler scheduler) throws SchedulerException {
-        final boolean ready = currentJobGroupMatcher == null || scheduler.getJobKeys(currentJobGroupMatcher).isEmpty();
-        if(ready)
-            startJobs(scheduler);
-    }
-
-
-    void startJob(final Scheduler scheduler, JobKey job)
-            throws SchedulerException {
-        TriggerKey triggerKey = new TriggerKey(job.getName(), 
-                job.getGroup() + WorkflowRule.TRIGGER_GROUP_UUID);
-        try {
-            scheduler.scheduleJob(TriggerBuilder.newTrigger()
-                    .withIdentity(triggerKey)
-                    .withPriority(triggerPriority)
-                    .forJob(job).startNow().build());
-        } catch (ObjectAlreadyExistsException e) {
-            ignoreRaceConditions();
-        } catch (JobPersistenceException e) {
-            if(scheduler.checkExists(job))
-                throw e;
-            else
-                ignoreRaceConditions();
-        }
-    }
-
-    private void ignoreRaceConditions() {/**/}
 }

--- a/quartz-core/src/test/java/org/quartz/workflow/WorkflowRuleTest.java
+++ b/quartz-core/src/test/java/org/quartz/workflow/WorkflowRuleTest.java
@@ -1,0 +1,180 @@
+/*
+ * Created on Jan 27, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.quartz.JobKey;
+import org.quartz.JobPersistenceException;
+import org.quartz.ObjectAlreadyExistsException;
+import org.quartz.Scheduler;
+import org.quartz.Trigger;
+import org.quartz.impl.matchers.GroupMatcher;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("boxing")
+public class WorkflowRuleTest {
+    @Mock private Scheduler scheduler;
+    @Captor ArgumentCaptor<Trigger> triggerCaptor;
+
+    @Test
+    public void singleJobRuleSchedulesJobImmediately() throws Exception {
+        final JobKey job = new JobKey("name", "group");
+
+        final WorkflowRule uut = new SingleJobRule(job);
+        uut.startJobsIfReady(scheduler);
+
+        verify(scheduler).scheduleJob(triggerCaptor.capture());
+        final Trigger trigger = triggerCaptor.getValue();
+        assertThat(trigger.getStartTime(), lessThanOrEqualTo(new Date()));
+    }
+
+
+    @Test
+    public void groupJobRuleSchedulesJobImmediately() throws Exception {
+        final JobKey job = new JobKey("name", "following");
+        GroupMatcher<JobKey> currentGroup = GroupMatcher.groupEquals("group");
+        GroupMatcher<JobKey> followingGroup = GroupMatcher.groupEquals("following");
+
+        when(scheduler.getJobKeys(currentGroup)).thenReturn(Collections.emptySet());
+        when(scheduler.getJobKeys(followingGroup)).thenReturn(Collections.singleton(job));
+
+        final WorkflowRule uut = new GroupRule(currentGroup, followingGroup);
+        uut.startJobsIfReady(scheduler);
+
+        verify(scheduler).scheduleJob(triggerCaptor.capture());
+        final Trigger trigger = triggerCaptor.getValue();
+        assertThat(trigger.getStartTime(), lessThanOrEqualTo(new Date()));
+    }
+
+    @Test
+    public void singleJobRuleSchedulesNoJob_whenGroupIsNotDone() throws Exception {
+        final JobKey job = new JobKey("name", "group");
+        GroupMatcher<JobKey> currentGroup = GroupMatcher.groupEquals("group");
+        when(scheduler.getJobKeys(currentGroup)).thenReturn(Collections.singleton(new JobKey("other", "group")));
+        GroupMatcher<JobKey> followingGroup = GroupMatcher.groupEquals("following");
+
+        final SingleJobRule uut = new SingleJobRule(currentGroup, job);
+        uut.startJobsIfReady(scheduler);
+
+        verify(scheduler, never()).getJobKeys(followingGroup);
+        verify(scheduler, never()).scheduleJob(any());
+    }
+
+    @Test
+    public void groupRuleSchedulesNoJob_whenGroupIsNotDone() throws Exception {
+        GroupMatcher<JobKey> currentGroup = GroupMatcher.groupEquals("group");
+
+        when(scheduler.getJobKeys(currentGroup)).thenReturn(Collections.singleton(new JobKey("other", "group")));
+        GroupMatcher<JobKey> followingGroup = GroupMatcher.groupEquals("following");
+
+        final GroupRule uut = new GroupRule(currentGroup, followingGroup);
+        uut.startJobsIfReady(scheduler);
+
+        verify(scheduler, never()).getJobKeys(followingGroup);
+        verify(scheduler, never()).scheduleJob(any());
+    }
+
+    @Test
+    public void schedulesJobWithDefaultPrority() throws Exception {
+        final JobKey job = new JobKey("name", "group");
+
+        final WorkflowRule uut = new SingleJobRule(job);
+        uut.startJobs(scheduler);
+
+        verify(scheduler).scheduleJob(triggerCaptor.capture());
+        final Trigger trigger = triggerCaptor.getValue();
+        assertEquals(Trigger.DEFAULT_PRIORITY, trigger.getPriority());
+    }
+
+    @Test
+    public void schedulesJobWithGivenPrority() throws Exception {
+        final JobKey job = new JobKey("name", "group");
+        final int priority = Trigger.DEFAULT_PRIORITY + 1;
+
+        final WorkflowRule uut = new SingleJobRule(job).setTriggerPriority(priority);
+        uut.startJobs(scheduler);
+
+        verify(scheduler).scheduleJob(triggerCaptor.capture());
+        final Trigger trigger = triggerCaptor.getValue();
+        assertEquals(priority, trigger.getPriority());
+    }
+
+    @Test
+    public void usesSameTriggerKeyForSameJobKey() throws Exception {
+        final JobKey job = new JobKey("name", "group");
+
+        final WorkflowRule uut = new SingleJobRule(job).setTriggerPriority(32);
+        uut.startJobs(scheduler);
+        uut.startJobs(scheduler);
+
+        verify(scheduler, times(2)).scheduleJob(triggerCaptor.capture());
+        final List<Trigger> triggers = triggerCaptor.getAllValues();
+
+        assertEquals(triggers.get(0).getKey(), triggers.get(1).getKey());
+    }
+
+    @Test
+    public void usesDifferentTriggerKeysForDifferentJobKeys() throws Exception {
+        new SingleJobRule(new JobKey("name1", "group")).startJobs(scheduler);
+        new SingleJobRule(new JobKey("name2", "group")).startJobs(scheduler);
+
+        verify(scheduler, times(2)).scheduleJob(triggerCaptor.capture());
+        final List<Trigger> triggers = triggerCaptor.getAllValues();
+        assertThat(triggers.get(0).getKey(), not(equalTo(triggers.get(1).getKey())));
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void ignoresExceptionIfWorkflowStartsTheSameJobTwice() throws Exception {
+        final JobKey job = new JobKey("name", "group");
+        final WorkflowRule uut = new SingleJobRule(job);
+        when(scheduler.scheduleJob(any())).thenThrow(ObjectAlreadyExistsException.class);
+
+        uut.startJobs(scheduler);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void ignoresExceptionIfWorkflowStartsAlreadyDoneJob() throws Exception {
+        final JobKey job = new JobKey("name", "group");
+        final WorkflowRule uut = new SingleJobRule(job);
+        when(scheduler.scheduleJob(any())).thenThrow(JobPersistenceException.class);
+
+        uut.startJobs(scheduler);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = JobPersistenceException.class)
+    public void rethrowsJobPersistenceExceptionIfJobIsNotDone() throws Exception {
+        final JobKey job = new JobKey("name", "group");
+        when(scheduler.scheduleJob(any())).thenThrow(JobPersistenceException.class);
+        when(scheduler.checkExists(job)).thenReturn(true);
+
+        final WorkflowRule uut = new SingleJobRule(job);
+        uut.startJobs(scheduler);
+    }
+}

--- a/quartz-core/src/test/java/org/quartz/workflow/WorkflowRuleTest.java
+++ b/quartz-core/src/test/java/org/quartz/workflow/WorkflowRuleTest.java
@@ -44,7 +44,7 @@ public class WorkflowRuleTest {
         final JobKey job = new JobKey("name", "group");
 
         final WorkflowRule uut = new SingleJobRule(job);
-        uut.startJobsIfReady(scheduler);
+        uut.apply(x -> scheduler);
 
         verify(scheduler).scheduleJob(triggerCaptor.capture());
         final Trigger trigger = triggerCaptor.getValue();
@@ -61,8 +61,8 @@ public class WorkflowRuleTest {
         when(scheduler.getJobKeys(currentGroup)).thenReturn(Collections.emptySet());
         when(scheduler.getJobKeys(followingGroup)).thenReturn(Collections.singleton(job));
 
-        final WorkflowRule uut = new GroupRule(currentGroup, followingGroup);
-        uut.startJobsIfReady(scheduler);
+        final WorkflowRule uut = new ConditionalRule(currentGroup, followingGroup);
+        uut.apply(x -> scheduler);
 
         verify(scheduler).scheduleJob(triggerCaptor.capture());
         final Trigger trigger = triggerCaptor.getValue();
@@ -76,8 +76,8 @@ public class WorkflowRuleTest {
         when(scheduler.getJobKeys(currentGroup)).thenReturn(Collections.singleton(new JobKey("other", "group")));
         GroupMatcher<JobKey> followingGroup = GroupMatcher.groupEquals("following");
 
-        final SingleJobRule uut = new SingleJobRule(currentGroup, job);
-        uut.startJobsIfReady(scheduler);
+        final WorkflowRule uut = new ConditionalRule(currentGroup, job);
+        uut.apply(x -> scheduler);
 
         verify(scheduler, never()).getJobKeys(followingGroup);
         verify(scheduler, never()).scheduleJob(any());
@@ -90,8 +90,8 @@ public class WorkflowRuleTest {
         when(scheduler.getJobKeys(currentGroup)).thenReturn(Collections.singleton(new JobKey("other", "group")));
         GroupMatcher<JobKey> followingGroup = GroupMatcher.groupEquals("following");
 
-        final GroupRule uut = new GroupRule(currentGroup, followingGroup);
-        uut.startJobsIfReady(scheduler);
+        final WorkflowRule uut = new ConditionalRule(currentGroup, followingGroup);
+        uut.apply(x -> scheduler);
 
         verify(scheduler, never()).getJobKeys(followingGroup);
         verify(scheduler, never()).scheduleJob(any());
@@ -102,7 +102,7 @@ public class WorkflowRuleTest {
         final JobKey job = new JobKey("name", "group");
 
         final WorkflowRule uut = new SingleJobRule(job);
-        uut.startJobs(scheduler);
+        uut.apply(x -> scheduler);
 
         verify(scheduler).scheduleJob(triggerCaptor.capture());
         final Trigger trigger = triggerCaptor.getValue();
@@ -115,7 +115,7 @@ public class WorkflowRuleTest {
         final int priority = Trigger.DEFAULT_PRIORITY + 1;
 
         final WorkflowRule uut = new SingleJobRule(job).setTriggerPriority(priority);
-        uut.startJobs(scheduler);
+        uut.apply(x -> scheduler);
 
         verify(scheduler).scheduleJob(triggerCaptor.capture());
         final Trigger trigger = triggerCaptor.getValue();
@@ -127,8 +127,8 @@ public class WorkflowRuleTest {
         final JobKey job = new JobKey("name", "group");
 
         final WorkflowRule uut = new SingleJobRule(job).setTriggerPriority(32);
-        uut.startJobs(scheduler);
-        uut.startJobs(scheduler);
+        uut.apply(x -> scheduler);
+        uut.apply(x -> scheduler);
 
         verify(scheduler, times(2)).scheduleJob(triggerCaptor.capture());
         final List<Trigger> triggers = triggerCaptor.getAllValues();
@@ -138,8 +138,8 @@ public class WorkflowRuleTest {
 
     @Test
     public void usesDifferentTriggerKeysForDifferentJobKeys() throws Exception {
-        new SingleJobRule(new JobKey("name1", "group")).startJobs(scheduler);
-        new SingleJobRule(new JobKey("name2", "group")).startJobs(scheduler);
+        new SingleJobRule(new JobKey("name1", "group")).apply(x -> scheduler);
+        new SingleJobRule(new JobKey("name2", "group")).apply(x -> scheduler);
 
         verify(scheduler, times(2)).scheduleJob(triggerCaptor.capture());
         final List<Trigger> triggers = triggerCaptor.getAllValues();
@@ -154,7 +154,7 @@ public class WorkflowRuleTest {
         final WorkflowRule uut = new SingleJobRule(job);
         when(scheduler.scheduleJob(any())).thenThrow(ObjectAlreadyExistsException.class);
 
-        uut.startJobs(scheduler);
+        uut.apply(x -> scheduler);
     }
 
     @SuppressWarnings("unchecked")
@@ -164,7 +164,7 @@ public class WorkflowRuleTest {
         final WorkflowRule uut = new SingleJobRule(job);
         when(scheduler.scheduleJob(any())).thenThrow(JobPersistenceException.class);
 
-        uut.startJobs(scheduler);
+        uut.apply(x -> scheduler);
     }
 
     @SuppressWarnings("unchecked")
@@ -175,6 +175,6 @@ public class WorkflowRuleTest {
         when(scheduler.checkExists(job)).thenReturn(true);
 
         final WorkflowRule uut = new SingleJobRule(job);
-        uut.startJobs(scheduler);
+        uut.apply(x -> scheduler);
     }
 }

--- a/quartz-core/src/test/java/org/quartz/workflow/WorkflowTest.java
+++ b/quartz-core/src/test/java/org/quartz/workflow/WorkflowTest.java
@@ -8,15 +8,20 @@ package org.quartz.workflow;
 
 import static junit.framework.Assert.assertEquals;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.Semaphore;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -29,8 +34,6 @@ import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.SchedulerFactory;
-import org.quartz.Trigger;
-import org.quartz.TriggerBuilder;
 import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.spi.TriggerFiredBundle;
@@ -46,33 +49,56 @@ public class WorkflowTest {
         }
     }
 
-    final static Trigger startNow = TriggerBuilder.newTrigger().withIdentity("triggerName", "triggerGroup")
-            .startNow().build();
 
-    @SuppressWarnings("null")
-    static Scheduler scheduler;
+    private static Scheduler schedulerA;
+    private static Scheduler schedulerB;
 
     private Workflow workflow;
     private Semaphore semaphore;
     
     private List<JobDetail> capturedDetails;
     @BeforeClass
-    public static void startScheduler() throws SchedulerException {
-        SchedulerFactory sf = new StdSchedulerFactory();
-        scheduler = sf.getScheduler();
-        scheduler.start();
+    public static void startScheduler() throws SchedulerException, IOException {
+        Properties configA = loadDefaultSchedulerConfiguration();
+        Properties configB = loadDefaultSchedulerConfiguration();
+        
+
+        configA.setProperty(StdSchedulerFactory.PROP_SCHED_INSTANCE_NAME, "A");
+        configB.setProperty(StdSchedulerFactory.PROP_SCHED_INSTANCE_NAME, "B");
+
+        
+        schedulerA = new StdSchedulerFactory(configA).getScheduler();
+        schedulerB = new StdSchedulerFactory(configB).getScheduler();
+        schedulerA.start();
+        schedulerB.start();
     }
+
+    private static Properties loadDefaultSchedulerConfiguration() throws IOException {
+        Properties configA = new Properties();
+        try(InputStream defaultConfig = SchedulerFactory.class.getResourceAsStream("quartz.properties")){
+            configA.load(defaultConfig);
+        }
+        return configA;
+    }
+    
     @AfterClass
     public static void stopScheduler() throws SchedulerException {
-         scheduler.shutdown();
+        schedulerA.shutdown();
+        schedulerB.shutdown();
     }
     
     @Before
     public void setup() throws SchedulerException {
-        scheduler.setJobFactory(this::newConnectedTestJob);
-        workflow = new Workflow(scheduler);
+        schedulerA.setJobFactory(this::newConnectedTestJob);
+        schedulerB.setJobFactory(this::newConnectedTestJob);
+        workflow = new Workflow();
         semaphore = new Semaphore(0);
         capturedDetails = Collections.synchronizedList(new ArrayList<>());
+    }
+    
+    @After
+    public void unregisterWorkflow() throws SchedulerException {
+        workflow.remove();
     }
     
     private Job newConnectedTestJob(TriggerFiredBundle bundle, @SuppressWarnings("unused") Scheduler scheduler){
@@ -93,14 +119,14 @@ public class WorkflowTest {
         
         final WorkflowRule rule = new SingleJobRule(followingJob1.getKey());
         
-        workflow.addJob(job1, rule);
-        workflow.addJob(followingJob1);
+        workflow.addJob(schedulerA, job1, rule);
+        workflow.addJob(schedulerA, followingJob1);
         
-        workflow.startJob(job1.getKey());
+        workflow.startJob(schedulerA, job1.getKey());
         
         waitUntilJobsAreDone(2);
-        assertThat(capturedDetails, containsInAnyOrder(job1, followingJob1));
-        assertThat(scheduler.getJobGroupNames(), not(contains("jobGroup1")));
+        assertThat(capturedDetails, contains(job1, followingJob1));
+        assertThat(schedulerA.getJobGroupNames(), not(contains("jobGroup1")));
     }
     
     @Test
@@ -114,17 +140,18 @@ public class WorkflowTest {
         
         final GroupMatcher<JobKey> group1Matcher = GroupMatcher.groupEquals("jobGroup1");
         
-        final WorkflowRule rule = new SingleJobRule(group1Matcher,followingJob1.getKey());
+        final WorkflowRule rule = new ConditionalRule(group1Matcher,followingJob1.getKey());
         
-        workflow.addJob(job1, rule);
-        workflow.addJob(job2, rule);
-        workflow.addJob(followingJob1);
+        workflow.addJob(schedulerA, job1, rule);
+        workflow.addJob(schedulerA, job2, rule);
+        workflow.addJob(schedulerA, followingJob1);
         
-        workflow.startJobs(group1Matcher);
+        workflow.startJobs(schedulerA, group1Matcher);
         
         waitUntilJobsAreDone(3);
-        assertThat(capturedDetails, containsInAnyOrder(job1, job2, followingJob1));
-        assertThat(scheduler.getJobGroupNames(), not(contains("jobGroup1")));
+        assertThat(capturedDetails.subList(0, 2), containsInAnyOrder(job1, job2));
+        assertThat(capturedDetails.get(2), equalTo(followingJob1));
+        assertThat(schedulerA.getJobGroupNames(), not(contains("jobGroup1")));
     }
     
     @Test
@@ -140,15 +167,16 @@ public class WorkflowTest {
         
         final WorkflowRule rule = new GroupRule(group2Matcher);
         
-        workflow.addJob(job1, rule);
-        workflow.addJob(followingJob1);
-        workflow.addJob(followingJob2);
+        workflow.addJob(schedulerA, job1, rule);
+        workflow.addJob(schedulerA, followingJob1);
+        workflow.addJob(schedulerA, followingJob2);
         
-        workflow.startJob(job1.getKey());
+        workflow.startJob(schedulerA, job1.getKey());
         
         waitUntilJobsAreDone(3);
-        assertThat(capturedDetails, containsInAnyOrder(job1, followingJob1, followingJob2));
-        assertThat(scheduler.getJobGroupNames(), not(contains("jobGroup1")));
+        assertThat(capturedDetails.get(0), equalTo(job1));
+        assertThat(capturedDetails.subList(1, 3), containsInAnyOrder(followingJob1, followingJob2));
+        assertThat(schedulerA.getJobGroupNames(), not(contains("jobGroup1")));
     }
     
     @Test
@@ -165,24 +193,85 @@ public class WorkflowTest {
         final GroupMatcher<JobKey> group1Matcher = GroupMatcher.groupEquals("jobGroup1");
         final GroupMatcher<JobKey> group2Matcher = GroupMatcher.groupEquals("jobGroup2");
         
-        final WorkflowRule rule = new GroupRule(group1Matcher,group2Matcher);
+        final WorkflowRule rule = new ConditionalRule(group1Matcher,group2Matcher);
         
-        workflow.addJob(job1, rule);
-        workflow.addJob(job2, rule);
-        workflow.addJob(followingJob1);
-        workflow.addJob(followingJob2);
+        workflow.addJob(schedulerA, job1, rule);
+        workflow.addJob(schedulerA, job2, rule);
+        workflow.addJob(schedulerA, followingJob1);
+        workflow.addJob(schedulerA, followingJob2);
         
-        workflow.startJobs(group1Matcher);
+        workflow.startJobs(schedulerA, group1Matcher);
         
         waitUntilJobsAreDone(4);
-        assertThat(capturedDetails, containsInAnyOrder(job1, job2, followingJob1, followingJob2));
-        assertThat(scheduler.getJobGroupNames(), not(contains("jobGroup1")));
+        assertThat(capturedDetails.subList(0, 2), containsInAnyOrder(job1, job2));
+        assertThat(capturedDetails.subList(2, 4), containsInAnyOrder(followingJob1, followingJob2));
+        assertThat(schedulerA.getJobGroupNames(), not(contains("jobGroup1")));
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void rejectsDurableJobs() throws Exception {
         final JobDetail job = JobBuilder.newJob().ofType(ConnectedTestJob.class).storeDurably().build();
-        workflow.addJob(job);
+        workflow.addJob(schedulerA, job);
+    }
+    @Test
+    public void runsSingleJobsInNamedSchedulers() throws Exception {
+        JobDetail job1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("job1", "jobGroup1").build();
+        JobDetail job2 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("job2", "jobGroup1").build();
+        JobDetail followingJob1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("followingJob1", "jobGroup2").build();
+        JobDetail followingJob2 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("followingJob2", "jobGroup2").build();
+        
+        final WorkflowRule rule =  new ConditionalRule(
+                WorkflowCondition.with("A", job1.getKey()).with("B", job2.getKey()),
+                WorkflowRule.with("A", followingJob1.getKey()).with("B", followingJob2.getKey()));
+        
+        workflow.addJob(schedulerA, job1, rule);
+        workflow.addJob(schedulerB, job2, rule);
+        workflow.addJob(schedulerA, followingJob1);
+        workflow.addJob(schedulerB, followingJob2);
+        
+        workflow.startJob(schedulerA, job1.getKey());
+        workflow.startJob(schedulerB, job2.getKey());
+        
+        waitUntilJobsAreDone(4);
+        assertThat(capturedDetails.subList(0, 2), containsInAnyOrder(job1, job2));
+        assertThat(capturedDetails.subList(2, 4), containsInAnyOrder(followingJob1, followingJob2));
+        assertThat(schedulerA.getJobGroupNames(), not(contains("jobGroup1")));
+    }
+
+    @Test
+    public void runsGroupJobsInMultipleSchedulers() throws Exception {
+        JobDetail job1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("job1", "jobGroup1").build();
+        JobDetail job2 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("job2", "jobGroup1").build();
+        JobDetail followingJob1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("followingJob1", "jobGroup2").build();
+        JobDetail followingJob2 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("followingJob2", "jobGroup2").build();
+        
+        final GroupMatcher<JobKey> group1Matcher = GroupMatcher.groupEquals("jobGroup1");
+        final GroupMatcher<JobKey> group2Matcher = GroupMatcher.groupEquals("jobGroup2");
+        
+        final WorkflowRule rule =  new ConditionalRule(
+                WorkflowCondition.with("A", group1Matcher).with("B", group1Matcher),
+                WorkflowRule.with("A", group2Matcher).with("B", group2Matcher));
+        
+        workflow.addJob(schedulerA, job1, rule);
+        workflow.addJob(schedulerB, job2, rule);
+        workflow.addJob(schedulerA, followingJob1);
+        workflow.addJob(schedulerB, followingJob2);
+        
+        workflow.startJobs(schedulerA, group1Matcher);
+        workflow.startJobs(schedulerB, group1Matcher);
+        
+        waitUntilJobsAreDone(4);
+        assertThat(capturedDetails.subList(0, 2), containsInAnyOrder(job1, job2));
+        assertThat(capturedDetails.subList(2, 4), containsInAnyOrder(followingJob1, followingJob2));
+        assertThat(schedulerA.getJobGroupNames(), not(contains("jobGroup1")));
     }
 
   }

--- a/quartz-core/src/test/java/org/quartz/workflow/WorkflowTest.java
+++ b/quartz-core/src/test/java/org/quartz/workflow/WorkflowTest.java
@@ -1,0 +1,188 @@
+/*
+ * Created on Jan 26, 2021
+ *
+ * author dimitry
+ */
+package org.quartz.workflow;
+
+
+import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SchedulerFactory;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.impl.StdSchedulerFactory;
+import org.quartz.impl.matchers.GroupMatcher;
+import org.quartz.spi.TriggerFiredBundle;
+
+@SuppressWarnings("null")
+public class WorkflowTest {
+    
+    class ConnectedTestJob implements Job{
+        @Override
+        public void execute(JobExecutionContext context) {
+            capturedDetails.add(context.getJobDetail());
+            semaphore.release();
+        }
+    }
+
+    final static Trigger startNow = TriggerBuilder.newTrigger().withIdentity("triggerName", "triggerGroup")
+            .startNow().build();
+
+    @SuppressWarnings("null")
+    static Scheduler scheduler;
+
+    private Workflow workflow;
+    private Semaphore semaphore;
+    
+    private List<JobDetail> capturedDetails;
+    @BeforeClass
+    public static void startScheduler() throws SchedulerException {
+        SchedulerFactory sf = new StdSchedulerFactory();
+        scheduler = sf.getScheduler();
+        scheduler.start();
+    }
+    @AfterClass
+    public static void stopScheduler() throws SchedulerException {
+         scheduler.shutdown();
+    }
+    
+    @Before
+    public void setup() throws SchedulerException {
+        scheduler.setJobFactory(this::newConnectedTestJob);
+        workflow = new Workflow(scheduler);
+        semaphore = new Semaphore(0);
+        capturedDetails = Collections.synchronizedList(new ArrayList<>());
+    }
+    
+    private Job newConnectedTestJob(TriggerFiredBundle bundle, @SuppressWarnings("unused") Scheduler scheduler){
+        assertEquals(ConnectedTestJob.class, bundle.getJobDetail().getJobClass());
+        return new ConnectedTestJob();
+    }
+
+    private void waitUntilJobsAreDone(final int jobCount) throws InterruptedException {
+        semaphore.acquire(jobCount);
+    }
+    
+    @Test
+    public void runsSingleFollowingJob_whenCurrentJobIsDone() throws Exception {
+        JobDetail job1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("job1", "jobGroup1").build();
+        JobDetail followingJob1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("followingJob1", "jobGroup2").build();
+        
+        final WorkflowRule rule = new SingleJobRule(followingJob1.getKey());
+        
+        workflow.addJob(job1, rule);
+        workflow.addJob(followingJob1);
+        
+        workflow.startJob(job1.getKey());
+        
+        waitUntilJobsAreDone(2);
+        assertThat(capturedDetails, containsInAnyOrder(job1, followingJob1));
+        assertThat(scheduler.getJobGroupNames(), not(contains("jobGroup1")));
+    }
+    
+    @Test
+    public void runsSingleFollowingJob_whenAllCurrentJobsAreDone() throws Exception {
+        JobDetail job1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("job1", "jobGroup1").build();
+        JobDetail job2 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("job2", "jobGroup1").build();
+        JobDetail followingJob1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("followingJob1", "jobGroup2").build();
+        
+        final GroupMatcher<JobKey> group1Matcher = GroupMatcher.groupEquals("jobGroup1");
+        
+        final WorkflowRule rule = new SingleJobRule(group1Matcher,followingJob1.getKey());
+        
+        workflow.addJob(job1, rule);
+        workflow.addJob(job2, rule);
+        workflow.addJob(followingJob1);
+        
+        workflow.startJobs(group1Matcher);
+        
+        waitUntilJobsAreDone(3);
+        assertThat(capturedDetails, containsInAnyOrder(job1, job2, followingJob1));
+        assertThat(scheduler.getJobGroupNames(), not(contains("jobGroup1")));
+    }
+    
+    @Test
+    public void runsAllJobsFollowingGroup_whenCurrentJobIsDone() throws Exception {
+        JobDetail job1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("job1", "jobGroup1").build();
+        JobDetail followingJob1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("followingJob1", "jobGroup2").build();
+        JobDetail followingJob2 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("followingJob2", "jobGroup2").build();
+        
+        final GroupMatcher<JobKey> group2Matcher = GroupMatcher.groupEquals("jobGroup2");
+        
+        final WorkflowRule rule = new GroupRule(group2Matcher);
+        
+        workflow.addJob(job1, rule);
+        workflow.addJob(followingJob1);
+        workflow.addJob(followingJob2);
+        
+        workflow.startJob(job1.getKey());
+        
+        waitUntilJobsAreDone(3);
+        assertThat(capturedDetails, containsInAnyOrder(job1, followingJob1, followingJob2));
+        assertThat(scheduler.getJobGroupNames(), not(contains("jobGroup1")));
+    }
+    
+    @Test
+    public void runsAllJobsFollowingGroup_whenAllCurrentJobsAreDone() throws Exception {
+        JobDetail job1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("job1", "jobGroup1").build();
+        JobDetail job2 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("job2", "jobGroup1").build();
+        JobDetail followingJob1 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("followingJob1", "jobGroup2").build();
+        JobDetail followingJob2 = JobBuilder.newJob().ofType(ConnectedTestJob.class)
+        .withIdentity("followingJob2", "jobGroup2").build();
+        
+        final GroupMatcher<JobKey> group1Matcher = GroupMatcher.groupEquals("jobGroup1");
+        final GroupMatcher<JobKey> group2Matcher = GroupMatcher.groupEquals("jobGroup2");
+        
+        final WorkflowRule rule = new GroupRule(group1Matcher,group2Matcher);
+        
+        workflow.addJob(job1, rule);
+        workflow.addJob(job2, rule);
+        workflow.addJob(followingJob1);
+        workflow.addJob(followingJob2);
+        
+        workflow.startJobs(group1Matcher);
+        
+        waitUntilJobsAreDone(4);
+        assertThat(capturedDetails, containsInAnyOrder(job1, job2, followingJob1, followingJob2));
+        assertThat(scheduler.getJobGroupNames(), not(contains("jobGroup1")));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsDurableJobs() throws Exception {
+        final JobDetail job = JobBuilder.newJob().ofType(ConnectedTestJob.class).storeDurably().build();
+        workflow.addJob(job);
+    }
+
+  }


### PR DESCRIPTION
A small extension to Quartz allows to automatically trigger jobs when some jobs or matched groups of jobs are finished.
Consider WorkflowTest to see the usage. 

It is particularly useful if the JDBC store is used and if jobs are automatically restarted after a server shutdown because it allows creating light-weight resilient systems.

Any feedback and suggestions are appreciated.
