### PR TITLE
Fix DailyTimeIntervalTriggerPersistenceDelegate trigger type check

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/DailyTimeIntervalTriggerPersistenceDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/DailyTimeIntervalTriggerPersistenceDelegate.java
@@ -41,7 +41,7 @@ import org.quartz.spi.OperableTrigger;
 public class DailyTimeIntervalTriggerPersistenceDelegate extends SimplePropertiesTriggerPersistenceDelegateSupport {
 
     public boolean canHandleTriggerType(OperableTrigger trigger) {
-        return ((trigger instanceof DailyTimeIntervalTrigger) && !((DailyTimeIntervalTriggerImpl)trigger).hasAdditionalProperties());
+        return ((trigger instanceof DailyTimeIntervalTriggerImpl) && !((DailyTimeIntervalTriggerImpl)trigger).hasAdditionalProperties());
     }
 
     public String getHandledTriggerTypeDiscriminator() {


### PR DESCRIPTION
Fix of instanceof check in canHandleTriggerType() method. Because of this bug, for any inheritance from DailyTimeIntervalTrigger, we get ClassCastException