### PR TITLE
Tutorial Links Documentation Fix

### DIFF
--- a/docs/tutorials/index.adoc
+++ b/docs/tutorials/index.adoc
@@ -9,28 +9,28 @@ Before starting the tutorial, you may first want to review the <<../quick-start-
 
 link:tutorial-lesson-01.md[Lesson 1: Using Quartz]
 
-link:tutorial-lesson-02.html[Lesson 2: The Quartz API, and Introduction to Jobs And Triggers]
+link:tutorial-lesson-02.md[Lesson 2: The Quartz API, and Introduction to Jobs And Triggers]
 
-link:tutorial-lesson-03.html[Lesson 3: More About Jobs &amp; JobDetails]
+link:tutorial-lesson-03.md[Lesson 3: More About Jobs &amp; JobDetails]
 
-link:tutorial-lesson-04.html[Lesson 4: More About Triggers]
+link:tutorial-lesson-04.md[Lesson 4: More About Triggers]
 
-link:tutorial-lesson-05.html[Lesson 5: SimpleTriggers]
+link:tutorial-lesson-05.md[Lesson 5: SimpleTriggers]
 
-link:tutorial-lesson-06.html[Lesson 6: CronTriggers]
+link:tutorial-lesson-06.md[Lesson 6: CronTriggers]
 
-link:tutorial-lesson-07.html[Lesson 7: TriggerListeners &amp; JobListeners]
+link:tutorial-lesson-07.md[Lesson 7: TriggerListeners &amp; JobListeners]
 
-link:tutorial-lesson-08.html[Lesson 8: SchedulerListeners]
+link:tutorial-lesson-08.md[Lesson 8: SchedulerListeners]
 
-link:tutorial-lesson-09.html[Lesson 9: JobStores]
+link:tutorial-lesson-09.md[Lesson 9: JobStores]
 
-link:tutorial-lesson-10.html[Lesson 10: Configuration, Resource Usage and SchedulerFactory]
+link:tutorial-lesson-10.md[Lesson 10: Configuration, Resource Usage and SchedulerFactory]
 
-link:tutorial-lesson-11.html[Lesson 11: Advanced (Enterprise) Features]
+link:tutorial-lesson-11.md[Lesson 11: Advanced (Enterprise) Features]
 
-link:tutorial-lesson-12.html[Lesson 12: Miscellaneous Features]
+link:tutorial-lesson-12.md[Lesson 12: Miscellaneous Features]
 
 == Choose a Special Topic:
 
-link:crontrigger.html[CronTrigger Tutorial]
+link:crontrigger.md[CronTrigger Tutorial]

--- a/docs/tutorials/index.adoc
+++ b/docs/tutorials/index.adoc
@@ -7,7 +7,7 @@ Before starting the tutorial, you may first want to review the <<../quick-start-
 
 == Choose a Lesson:
 
-link:tutorial-lesson-01.html[Lesson 1: Using Quartz]
+link:tutorial-lesson-01.md[Lesson 1: Using Quartz]
 
 link:tutorial-lesson-02.html[Lesson 2: The Quartz API, and Introduction to Jobs And Triggers]
 

--- a/docs/tutorials/tutorial-lesson-04.md
+++ b/docs/tutorials/tutorial-lesson-04.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-03.html" title="Go to Lesson 3">&lsaquo;&nbsp;Lesson 3</a> |
-          <a href="tutorial-lesson-05.html" title="Go to Lesson 5">Lesson 5&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-03.md" title="Go to Lesson 3">&lsaquo;&nbsp;Lesson 3</a> |
+          <a href="tutorial-lesson-05.md" title="Go to Lesson 5">Lesson 5&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 4: More About Triggers
@@ -15,8 +15,8 @@ Like jobs, triggers are quite easy to work with, but do contain a variety of cus
 need to be aware of and understand before you can make full use of Quartz. Also, as noted earlier, there are different
 types of triggers that you can select from to meet different scheduling needs.
 
-You will learn about the two most common types of triggers in <a href="tutorial-lesson-05.html"
-    title="Tutorial Lesson 5">Lesson 5: Simple Triggers</a> and <a href="tutorial-lesson-06.html" title="Tutorial Lesson 6">Lesson 6: Cron Triggers</a>.
+You will learn about the two most common types of triggers in <a href="tutorial-lesson-05.md"
+    title="Tutorial Lesson 5">Lesson 5: Simple Triggers</a> and <a href="tutorial-lesson-06.md" title="Tutorial Lesson 6">Lesson 6: Cron Triggers</a>.
 
 ### [Common Trigger Attributes](#TutorialLesson4-CommonAttrs)
 

--- a/docs/tutorials/tutorial-lesson-05.md
+++ b/docs/tutorials/tutorial-lesson-05.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-04.html" title="Go to Lesson 4">&lsaquo;&nbsp;Lesson 4</a> |
-          <a href="tutorial-lesson-06.html" title="Go to Lesson 6">Lesson 6&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-04.md" title="Go to Lesson 4">&lsaquo;&nbsp;Lesson 4</a> |
+          <a href="tutorial-lesson-06.md" title="Go to Lesson 6">Lesson 6&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 5: SimpleTrigger

--- a/docs/tutorials/tutorial-lesson-06.md
+++ b/docs/tutorials/tutorial-lesson-06.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-05.html" title="Go to Lesson 5">&lsaquo;&nbsp;Lesson 5</a> |
-          <a href="tutorial-lesson-07.html" title="Go to Lesson 7">Lesson 7&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-05.md" title="Go to Lesson 5">&lsaquo;&nbsp;Lesson 5</a> |
+          <a href="tutorial-lesson-07.md" title="Go to Lesson 7">Lesson 7&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 6: CronTrigger

--- a/docs/tutorials/tutorial-lesson-07.md
+++ b/docs/tutorials/tutorial-lesson-07.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-06.html" title="Go to Lesson 6">&lsaquo;&nbsp;Lesson 6</a> |
-          <a href="tutorial-lesson-08.html" title="Go to Lesson 8">Lesson 8&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-06.md" title="Go to Lesson 6">&lsaquo;&nbsp;Lesson 6</a> |
+          <a href="tutorial-lesson-08.md" title="Go to Lesson 8">Lesson 8&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 7: TriggerListeners and JobListeners

--- a/docs/tutorials/tutorial-lesson-08.md
+++ b/docs/tutorials/tutorial-lesson-08.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-07.html" title="Go to Lesson 7">&lsaquo;&nbsp;Lesson 7</a> |
-          <a href="tutorial-lesson-09.html" title="Go to Lesson 9">Lesson 9&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-07.md" title="Go to Lesson 7">&lsaquo;&nbsp;Lesson 7</a> |
+          <a href="tutorial-lesson-09.md" title="Go to Lesson 9">Lesson 9&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 8: SchedulerListeners

--- a/docs/tutorials/tutorial-lesson-09.md
+++ b/docs/tutorials/tutorial-lesson-09.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-08.html" title="Go to Lesson 8">&lsaquo;&nbsp;Lesson 8</a> |
-          <a href="tutorial-lesson-10.html" title="Go to Lesson 10">Lesson 10&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-08.md" title="Go to Lesson 8">&lsaquo;&nbsp;Lesson 8</a> |
+          <a href="tutorial-lesson-10.md" title="Go to Lesson 10">Lesson 10&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 9: Job Stores

--- a/docs/tutorials/tutorial-lesson-10.md
+++ b/docs/tutorials/tutorial-lesson-10.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-09.html" title="Go to Lesson 9">&lsaquo;&nbsp;Lesson 9</a> |
-          <a href="tutorial-lesson-11.html" title="Go to Lesson 11">Lesson 11&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-09.md" title="Go to Lesson 9">&lsaquo;&nbsp;Lesson 9</a> |
+          <a href="tutorial-lesson-11.md" title="Go to Lesson 11">Lesson 11&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 10: Configuration, Resource Usage and SchedulerFactory

--- a/docs/tutorials/tutorial-lesson-11.md
+++ b/docs/tutorials/tutorial-lesson-11.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-10.html" title="Go to Lesson 10">&lsaquo;&nbsp;Lesson 10</a> |
-          <a href="tutorial-lesson-12.html" title="Go to Lesson 12">Lesson 12&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-10.md" title="Go to Lesson 10">&lsaquo;&nbsp;Lesson 10</a> |
+          <a href="tutorial-lesson-12.md" title="Go to Lesson 12">Lesson 12&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 11: Advanced (Enterprise) Features

--- a/docs/tutorials/tutorial-lesson-12.md
+++ b/docs/tutorials/tutorial-lesson-12.md
@@ -5,7 +5,7 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-11.html" title="Go to Lesson 2">&lsaquo;&nbsp;Lesson 11</a>
+          <a href="tutorial-lesson-11.md" title="Go to Lesson 2">&lsaquo;&nbsp;Lesson 11</a>
 </div>
 
 ## Lesson 12: Miscellaneous Features of Quartz


### PR DESCRIPTION
I was going through the tutorial and hit a 404 error in Index.adoc. I searched for the file I click on and found from the github search bar. To remedy the 404 I changed the extensions from .html to .md as they were listed in the directory and the links got me to the file when I clicked on them to continue with the tutorial. Hope this helps.