### PR TITLE
Add default empty stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,2 @@
+
+# Empty (using defaults from https://github.com/probot/stale)


### PR DESCRIPTION
Signed-off-by: akom <alexander.komarov@softwareag.com>

See https://github.com/probot/stale for defaults and let me know if we should change any.  
Bot is off until this file exists.