### PR TITLE
#580 fix wrong warning from #189 change

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/DriverDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/DriverDelegate.java
@@ -640,6 +640,7 @@ public interface DriverDelegate {
      */
     List<OperableTrigger> selectTriggersForCalendar(Connection conn, String calName)
         throws SQLException, ClassNotFoundException, IOException, JobPersistenceException;
+
     /**
      * <p>
      * Select a trigger.
@@ -653,6 +654,22 @@ public interface DriverDelegate {
      */
     OperableTrigger selectTrigger(Connection conn, TriggerKey triggerKey) throws SQLException, ClassNotFoundException,
         IOException, JobPersistenceException;
+
+    /**
+     * <p>
+     * Select a trigger in a given state.
+     * </p>
+     *
+     * @param conn
+     *          the DB Connection
+     * @param state
+     *          the state the trigger must be in or null if state does not matter
+     *
+     * @return the <code>{@link org.quartz.Trigger}</code> object
+     * @throws JobPersistenceException
+     */
+    OperableTrigger selectTriggerInState(Connection conn, TriggerKey triggerKey, String state) throws SQLException,
+            ClassNotFoundException, IOException, JobPersistenceException;
 
     /**
      * <p>

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -2850,8 +2850,13 @@ public abstract class JobStoreSupport implements JobStore, Constants {
                 long batchEnd = noLaterThan;
 
                 for(TriggerKey triggerKey: keys) {
-                    // If our trigger is no longer available, try a new one.
-                    OperableTrigger nextTrigger = retrieveTrigger(conn, triggerKey);
+                    // If our trigger is no longer available or no longer waiting, try a new one.
+                    OperableTrigger nextTrigger;
+                    try {
+                        nextTrigger = getDelegate().selectTriggerInState(conn, triggerKey, STATE_WAITING);
+                    } catch (Exception e) {
+                        throw new JobPersistenceException("Couldn't retrieve next trigger: " + e.getMessage(), e);
+                    }
                     if(nextTrigger == null) {
                         continue; // next trigger
                     }

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
@@ -396,6 +396,8 @@ public interface StdJDBCConstants extends Constants {
             + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
             + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
 
+    String SELECT_TRIGGER_IN_STATE = SELECT_TRIGGER + " AND " + COL_TRIGGER_STATE + " = ?";
+
     String SELECT_TRIGGER_DATA = "SELECT " + 
             COL_JOB_DATAMAP + " FROM "
             + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
@@ -1741,23 +1741,48 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
      * <p>
      * Select a trigger.
      * </p>
-     * 
+     *
      * @param conn
      *          the DB Connection
      * @return the <code>{@link org.quartz.Trigger}</code> object
-     * @throws JobPersistenceException 
+     * @throws JobPersistenceException
      */
     public OperableTrigger selectTrigger(Connection conn, TriggerKey triggerKey) throws SQLException, ClassNotFoundException,
             IOException, JobPersistenceException {
+
+        return selectTriggerInState(conn, triggerKey, null);
+    }
+
+    /**
+     * <p>
+     * Select a trigger in a given state.
+     * </p>
+     * 
+     * @param conn
+     *          the DB Connection
+     * @param state
+     *          the state the trigger must be in or null if state does not matter
+     * @return the <code>{@link org.quartz.Trigger}</code> object
+     * @throws JobPersistenceException 
+     */
+    public OperableTrigger selectTriggerInState(Connection conn, TriggerKey triggerKey, String state) throws SQLException,
+            ClassNotFoundException, IOException, JobPersistenceException {
         PreparedStatement ps = null;
         ResultSet rs = null;
 
         try {
             OperableTrigger trigger = null;
 
-            ps = conn.prepareStatement(rtp(SELECT_TRIGGER));
-            ps.setString(1, triggerKey.getName());
-            ps.setString(2, triggerKey.getGroup());
+            if (state == null) {
+                ps = conn.prepareStatement(rtp(SELECT_TRIGGER));
+                ps.setString(1, triggerKey.getName());
+                ps.setString(2, triggerKey.getGroup());
+            } else {
+                ps = conn.prepareStatement(rtp(SELECT_TRIGGER_IN_STATE));
+                ps.setString(1, triggerKey.getName());
+                ps.setString(2, triggerKey.getGroup());
+                ps.setString(3, state);
+            }
             rs = ps.executeQuery();
 
             if (rs.next()) {


### PR DESCRIPTION
Warning regularly appears due to race condition on multi-instance environments although nothing is wrong

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: https://github.com/quartz-scheduler/contributing/CONTRIBUTING.md
Err ... Not Found?

This PR...
## Changes
- Fixes a wrong warning message

## Checklist
- [x] tested locally
- [/] updated the docs - Does not seem necessary
- [/] added appropriate test - Does not seem necessary / No existing test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via -s on my commits. 
  (You can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) if you're not using command-line)

Fixes #580 

