### PR TITLE
Fix log level for job crash

### DIFF
--- a/quartz-core/src/main/java/org/quartz/core/JobRunShell.java
+++ b/quartz-core/src/main/java/org/quartz/core/JobRunShell.java
@@ -204,7 +204,7 @@ public class JobRunShell extends SchedulerListenerSupport implements Runnable {
                 } catch (JobExecutionException jee) {
                     endTime = System.currentTimeMillis();
                     jobExEx = jee;
-                    getLog().info("Job " + jobDetail.getKey() +
+                    getLog().warn("Job " + jobDetail.getKey() +
                             " threw a JobExecutionException: ", jobExEx);
                 } catch (Throwable e) {
                     endTime = System.currentTimeMillis();


### PR DESCRIPTION
An exception in a job cannot be classified as normal behaviour in the logs

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
- Fix log level mistake in job crash

## Checklist
- [ ] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

