### PR TITLE
Update QuartzInitializerServlet.java

### DIFF
--- a/quartz-core/src/main/java/org/quartz/ee/servlet/QuartzInitializerServlet.java
+++ b/quartz-core/src/main/java/org/quartz/ee/servlet/QuartzInitializerServlet.java
@@ -19,11 +19,11 @@ package org.quartz.ee.servlet;
 
 import java.io.IOException;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;

--- a/quartz-core/src/main/java/org/quartz/ee/servlet/QuartzInitializerServlet.java
+++ b/quartz-core/src/main/java/org/quartz/ee/servlet/QuartzInitializerServlet.java
@@ -161,7 +161,7 @@ public class QuartzInitializerServlet extends HttpServlet {
      */
 
     @Override
-    public void init(ServletConfig cfg) throws javax.servlet.ServletException {
+    public void init(ServletConfig cfg) throws ServletException {
         super.init(cfg);
 
         log("Quartz Initializer Servlet loaded, initializing Scheduler...");


### PR DESCRIPTION
Changed the import statement from javax.servlet.* to jakarta.servlet.* to be compatible with Tomcat 10 release

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
-

## Checklist
- [x] tested locally
- [x] updated the docs
- [x] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

