### PR TITLE
Fix the wrong parameter used in createScheduler

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/DirectSchedulerFactory.java
+++ b/quartz-core/src/main/java/org/quartz/impl/DirectSchedulerFactory.java
@@ -412,7 +412,7 @@ public class DirectSchedulerFactory implements SchedulerFactory {
             boolean jmxExport, String jmxObjectName)
         throws SchedulerException {
         createScheduler(schedulerName, schedulerInstanceId, threadPool,
-                DEFAULT_THREAD_EXECUTOR, jobStore, schedulerPluginMap,
+                threadExecutor, jobStore, schedulerPluginMap,
                 rmiRegistryHost, rmiRegistryPort, idleWaitTime,
                 dbFailureRetryInterval, jmxExport, jmxObjectName, DEFAULT_BATCH_MAX_SIZE, DEFAULT_BATCH_TIME_WINDOW);
     }


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR Fix the wrong parameter used in createScheduler

## Changes
- Fix the wrong parameter used in createScheduler

## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

