### PR TITLE
Fix StdRowLockSemaphore retry mechanism

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdRowLockSemaphore.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdRowLockSemaphore.java
@@ -171,6 +171,12 @@ public class StdRowLockSemaphore extends DBSemaphore {
                 }
                 
                 if(count < maxRetryLocal) {
+                    try {
+                        conn.rollback();
+                    } catch (SQLException e) {
+                        getLog().error(
+                                "Couldn't rollback jdbc connection. "+e.getMessage(), e);
+                    }
                     // pause a bit to give another thread some time to commit the insert of the new lock row
                     try {
                         Thread.sleep(retryPeriodLocal);


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR fixes the retry mechanism of StdRowLockSemaphore.

## Changes
- If connection is never rollbacked upon error and auto-commit is disabled, the transaction only ends when commit is called. In this case the retry never succeeds if it fails the first time when acquiring the lock.

## Checklist
- [x] tested locally
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

I believe it might be related to this already open issued - https://github.com/quartz-scheduler/quartz/issues/744.
