### PR TITLE
Udate HikariCP to 3.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <skipCheckstyle>false</skipCheckstyle>
     <slf4j.version>1.7.7</slf4j.version>
     <c3p0.version>0.9.5.4</c3p0.version>
-    <hikaricp.version>3.2.0</hikaricp.version>
+    <hikaricp.version>3.4.5</hikaricp.version>
     <log4j.version>1.2.17</log4j.version>
     <gmaven-plugin.version>1.4</gmaven-plugin.version>
     <checkstyle-suppressions-file>${user.dir}/checkstyle/src/main/resources/suppressions.xml</checkstyle-suppressions-file>


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
- Update HikariCP version to 3.4.5

## Checklist
- [X] tested locally
- [X] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

