### PR TITLE
Fix n plus one problem in scheduler

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/DriverDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/DriverDelegate.java
@@ -943,7 +943,7 @@ public interface DriverDelegate {
      * 
      * @deprecated - This remained for compatibility reason. Use {@link #selectTriggerToAcquire(Connection, long, long, int)} instead. 
      */
-    public List<TriggerKey> selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan)
+    public List<TriggerToAcquireDTO> selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan)
         throws SQLException;
     
     /**
@@ -963,7 +963,11 @@ public interface DriverDelegate {
      *          
      * @return A (never null, possibly empty) list of the identifiers (Key objects) of the next triggers to be fired.
      */
-    public List<TriggerKey> selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan, int maxCount)
+    public List<TriggerToAcquireDTO> selectTriggerToAcquire(
+            Connection conn, 
+            long noLaterThan, 
+            long noEarlierThan, 
+            int maxCount)
         throws SQLException;
 
     /**

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -2871,17 +2871,6 @@ public abstract class JobStoreSupport implements JobStore, Constants {
 
                     Date nextFireTime = nextTrigger.getNextFireTime();
 
-                    // A trigger should not return NULL on nextFireTime when fetched from DB.
-                    // But for whatever reason if we do have this (BAD trigger implementation or
-                    // data?), we then should log a warning and continue to next trigger.
-                    // User would need to manually fix these triggers from DB as they will not
-                    // able to be clean up by Quartz since we are not returning it to be processed.
-                    if (nextFireTime == null) {
-                        log.warn("Trigger {} returned null on nextFireTime and yet still exists in DB!",
-                            nextTrigger.getKey());
-                        continue;
-                    }
-                    
                     if (nextFireTime.getTime() > batchEnd) {
                       break;
                     }

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not 
- * use this file except in compliance with the License. You may obtain a copy 
- * of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- *   
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
- * 
+ *
  */
 
 package org.quartz.impl.jdbcjobstore;
@@ -27,16 +27,16 @@ import org.quartz.Trigger;
  * org.quartz.impl.jdbcjobstore.StdJDBCDelegate}</code>
  * class.
  * </p>
- * 
+ *
  * @author <a href="mailto:jeff@binaryfeed.org">Jeffrey Wescott</a>
  */
 public interface StdJDBCConstants extends Constants {
 
     /*
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     * 
+     *
      * Constants.
-     * 
+     *
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      */
 
@@ -47,619 +47,736 @@ public interface StdJDBCConstants extends Constants {
     String SCHED_NAME_SUBST = "{1}";
 
     // QUERIES
-    String UPDATE_TRIGGER_STATES_FROM_OTHER_STATES = "UPDATE "
-            + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS
-            + " SET "
-            + COL_TRIGGER_STATE
-            + " = ?"
-            + " WHERE "
-            + COL_SCHEDULER_NAME 
-            + " = " + SCHED_NAME_SUBST + " AND ("
-            + COL_TRIGGER_STATE
-            + " = ? OR "
-            + COL_TRIGGER_STATE + " = ?)";
+    String UPDATE_TRIGGER_STATES_FROM_OTHER_STATES =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " SET " + COL_TRIGGER_STATE + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND ( "
+            + COL_TRIGGER_STATE + " = ? "
+            + " OR " + COL_TRIGGER_STATE + " = ? "
+            + " )";
 
-    String SELECT_MISFIRED_TRIGGERS = "SELECT * FROM "
-        + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-        + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-        + " AND NOT ("
-        + COL_MISFIRE_INSTRUCTION + " = " + Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY + ") AND " 
-        + COL_NEXT_FIRE_TIME + " < ? "
-        + "ORDER BY " + COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
-    
-    String SELECT_TRIGGERS_IN_STATE = "SELECT "
-            + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + " FROM "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST + " AND "
-            + COL_TRIGGER_STATE + " = ?";
+    String SELECT_MISFIRED_TRIGGERS =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND NOT ("
+            + COL_MISFIRE_INSTRUCTION + " = " + Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY
+            + " ) AND " + COL_NEXT_FIRE_TIME + " < ? "
+            + " ORDER BY " + COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
 
-    String SELECT_MISFIRED_TRIGGERS_IN_STATE = "SELECT "
-        + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + " FROM "
-        + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-        + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST + " AND NOT ("
-        + COL_MISFIRE_INSTRUCTION + " = " + Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY + ") AND " 
-        + COL_NEXT_FIRE_TIME + " < ? AND " + COL_TRIGGER_STATE + " = ? "
-        + "ORDER BY " + COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
+    String SELECT_TRIGGERS_IN_STATE =
+            "SELECT " + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_STATE + " = ? ";
 
-    String COUNT_MISFIRED_TRIGGERS_IN_STATE = "SELECT COUNT("
-        + COL_TRIGGER_NAME + ") FROM "
-        + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-        + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST + " AND NOT ("
-        + COL_MISFIRE_INSTRUCTION + " = " + Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY + ") AND " 
-        + COL_NEXT_FIRE_TIME + " < ? " 
-        + "AND " + COL_TRIGGER_STATE + " = ?";
-    
-    String SELECT_HAS_MISFIRED_TRIGGERS_IN_STATE = "SELECT "
-        + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + " FROM "
-        + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-        + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST + " AND NOT ("
-        + COL_MISFIRE_INSTRUCTION + " = " + Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY + ") AND " 
-        + COL_NEXT_FIRE_TIME + " < ? " 
-        + "AND " + COL_TRIGGER_STATE + " = ? "
-        + "ORDER BY " + COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
+    String SELECT_MISFIRED_TRIGGERS_IN_STATE =
+            "SELECT " + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND NOT ("
+            + COL_MISFIRE_INSTRUCTION + " = " + Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY
+            + " ) AND " + COL_NEXT_FIRE_TIME + " < ? "
+            + " AND " + COL_TRIGGER_STATE + " = ? "
+            + " ORDER BY " + COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
 
-    String SELECT_MISFIRED_TRIGGERS_IN_GROUP_IN_STATE = "SELECT "
-        + COL_TRIGGER_NAME
-        + " FROM "
-        + TABLE_PREFIX_SUBST
-        + TABLE_TRIGGERS
-        + " WHERE "
-        + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST + " AND NOT ("
-        + COL_MISFIRE_INSTRUCTION + " = " + Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY + ") AND " 
-        + COL_NEXT_FIRE_TIME
-        + " < ? AND "
-        + COL_TRIGGER_GROUP
-        + " = ? AND " + COL_TRIGGER_STATE + " = ? "
-        + "ORDER BY " + COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
+    String COUNT_MISFIRED_TRIGGERS_IN_STATE =
+            "SELECT COUNT(" + COL_TRIGGER_NAME + ") "
+            + "FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND NOT (" + COL_MISFIRE_INSTRUCTION + " = " + Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY + ") "
+            + " AND " + COL_NEXT_FIRE_TIME + " < ? "
+            + " AND " + COL_TRIGGER_STATE + " = ? ";
 
+    String SELECT_HAS_MISFIRED_TRIGGERS_IN_STATE =
+            "SELECT " + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND NOT (" + COL_MISFIRE_INSTRUCTION + " = " + Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY + ") "
+            + " AND " + COL_NEXT_FIRE_TIME + " < ? "
+            + " AND " + COL_TRIGGER_STATE + " = ? "
+            + " ORDER BY " + COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
 
-    String DELETE_FIRED_TRIGGERS = "DELETE FROM "
-            + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
-            + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+    String SELECT_MISFIRED_TRIGGERS_IN_GROUP_IN_STATE =
+            "SELECT " + COL_TRIGGER_NAME
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND NOT (" + COL_MISFIRE_INSTRUCTION + " = " + Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY + ") "
+            + " AND " + COL_NEXT_FIRE_TIME + " < ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? "
+            + " AND " + COL_TRIGGER_STATE + " = ? "
+            + " ORDER BY " + COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
 
-    String INSERT_JOB_DETAIL = "INSERT INTO "
-            + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " (" 
-            + COL_SCHEDULER_NAME + ", " + COL_JOB_NAME
-            + ", " + COL_JOB_GROUP + ", " + COL_DESCRIPTION + ", "
-            + COL_JOB_CLASS + ", " + COL_IS_DURABLE + ", " 
-            + COL_IS_NONCONCURRENT +  ", " + COL_IS_UPDATE_DATA + ", " 
+    String DELETE_FIRED_TRIGGERS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+
+    String INSERT_JOB_DETAIL =
+            "INSERT INTO " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " ("
+            + COL_SCHEDULER_NAME + ", "
+            + COL_JOB_NAME + ", "
+            + COL_JOB_GROUP + ", "
+            + COL_DESCRIPTION + ", "
+            + COL_JOB_CLASS + ", "
+            + COL_IS_DURABLE + ", "
+            + COL_IS_NONCONCURRENT +  ", "
+            + COL_IS_UPDATE_DATA + ", "
             + COL_REQUESTS_RECOVERY + ", "
-            + COL_JOB_DATAMAP + ") " + " VALUES(" + SCHED_NAME_SUBST + ", ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            + COL_JOB_DATAMAP
+            + ") "
+            + " VALUES(" + SCHED_NAME_SUBST + ", ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
-    String UPDATE_JOB_DETAIL = "UPDATE "
-            + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " SET "
-            + COL_DESCRIPTION + " = ?, " + COL_JOB_CLASS + " = ?, "
-            + COL_IS_DURABLE + " = ?, " 
-            + COL_IS_NONCONCURRENT + " = ?, " + COL_IS_UPDATE_DATA + " = ?, " 
+    String UPDATE_JOB_DETAIL =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS
+            + " SET " + COL_DESCRIPTION + " = ?, "
+            + COL_JOB_CLASS + " = ?, "
+            + COL_IS_DURABLE + " = ?, "
+            + COL_IS_NONCONCURRENT + " = ?, "
+            + COL_IS_UPDATE_DATA + " = ?, "
             + COL_REQUESTS_RECOVERY + " = ?, "
-            + COL_JOB_DATAMAP + " = ? " + " WHERE " 
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST 
-            + " AND " + COL_JOB_NAME
-            + " = ? AND " + COL_JOB_GROUP + " = ?";
+            + COL_JOB_DATAMAP + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? "
+            + " AND " + COL_JOB_GROUP + " = ? ";
 
-    String SELECT_TRIGGERS_FOR_JOB = "SELECT "
-            + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + " FROM "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE " 
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST 
-            + " AND " + COL_JOB_NAME
-            + " = ? AND " + COL_JOB_GROUP + " = ?";
+    String SELECT_TRIGGERS_FOR_JOB =
+            "SELECT " + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? "
+            + " AND " + COL_JOB_GROUP + " = ? ";
 
-    String SELECT_TRIGGERS_FOR_CALENDAR = "SELECT "
-        + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + " FROM "
-        + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE " 
-        + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST 
-        + " AND " + COL_CALENDAR_NAME
-        + " = ?";
+    String SELECT_TRIGGERS_FOR_CALENDAR =
+            "SELECT " + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_CALENDAR_NAME + " = ? ";
 
-    String DELETE_JOB_DETAIL = "DELETE FROM "
-            + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " WHERE " 
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST 
-            + " AND " + COL_JOB_NAME
-            + " = ? AND " + COL_JOB_GROUP + " = ?";
+    String DELETE_JOB_DETAIL =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? "
+            + " AND " + COL_JOB_GROUP + " = ? ";
 
-    String SELECT_JOB_NONCONCURRENT = "SELECT "
-            + COL_IS_NONCONCURRENT + " FROM " + TABLE_PREFIX_SUBST
-            + TABLE_JOB_DETAILS + " WHERE " 
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST 
-            + " AND " + COL_JOB_NAME
-            + " = ? AND " + COL_JOB_GROUP + " = ?";
+    String SELECT_JOB_NONCONCURRENT =
+            "SELECT " + COL_IS_NONCONCURRENT
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? "
+            + " AND " + COL_JOB_GROUP + " = ? ";
 
-    String SELECT_JOB_EXISTENCE = "SELECT " + COL_JOB_NAME
-            + " FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST 
-            + " AND " + COL_JOB_NAME
-            + " = ? AND " + COL_JOB_GROUP + " = ?";
+    String SELECT_JOB_EXISTENCE =
+            "SELECT " + COL_JOB_NAME
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? "
+            + " AND " + COL_JOB_GROUP + " = ? ";
 
-    String UPDATE_JOB_DATA = "UPDATE " + TABLE_PREFIX_SUBST
-            + TABLE_JOB_DETAILS + " SET " + COL_JOB_DATAMAP + " = ? "
-            + " WHERE " 
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST 
-            + " AND " + COL_JOB_NAME
-            + " = ? AND " + COL_JOB_GROUP + " = ?";
+    String UPDATE_JOB_DATA =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS
+            + " SET " + COL_JOB_DATAMAP + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? "
+            + " AND " + COL_JOB_GROUP + " = ? ";
 
-    String SELECT_JOB_DETAIL = "SELECT *" + " FROM "
-            + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST 
-            + " AND " + COL_JOB_NAME
-            + " = ? AND " + COL_JOB_GROUP + " = ?";
-            
+    String SELECT_JOB_DETAIL =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? "
+            + " AND " + COL_JOB_GROUP + " = ? ";
 
-    String SELECT_NUM_JOBS = "SELECT COUNT(" + COL_JOB_NAME
-            + ") " + " FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
 
-    String SELECT_JOB_GROUPS = "SELECT DISTINCT("
-            + COL_JOB_GROUP + ") FROM " + TABLE_PREFIX_SUBST
-            + TABLE_JOB_DETAILS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+    String SELECT_NUM_JOBS =
+            "SELECT COUNT(" + COL_JOB_NAME + ") "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
 
-    String SELECT_JOBS_IN_GROUP_LIKE = "SELECT " + COL_JOB_NAME + ", " + COL_JOB_GROUP
-            + " FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_JOB_GROUP + " LIKE ?";
+    String SELECT_JOB_GROUPS =
+            "SELECT DISTINCT(" + COL_JOB_GROUP + ") "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
 
-    String SELECT_JOBS_IN_GROUP = "SELECT " + COL_JOB_NAME + ", " + COL_JOB_GROUP
-            + " FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_JOB_GROUP + " = ?";
+    String SELECT_JOBS_IN_GROUP_LIKE =
+            "SELECT " + COL_JOB_NAME + ", " + COL_JOB_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_GROUP + " LIKE ? ";
 
-    String INSERT_TRIGGER = "INSERT INTO "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " (" + COL_SCHEDULER_NAME + ", " + COL_TRIGGER_NAME
-            + ", " + COL_TRIGGER_GROUP + ", " + COL_JOB_NAME + ", "
-            + COL_JOB_GROUP + ", " + COL_DESCRIPTION
-            + ", " + COL_NEXT_FIRE_TIME + ", " + COL_PREV_FIRE_TIME + ", "
-            + COL_TRIGGER_STATE + ", " + COL_TRIGGER_TYPE + ", "
-            + COL_START_TIME + ", " + COL_END_TIME + ", " + COL_CALENDAR_NAME
-            + ", " + COL_MISFIRE_INSTRUCTION + ", " + COL_JOB_DATAMAP + ", " + COL_PRIORITY + ") "
+    String SELECT_JOBS_IN_GROUP =
+            "SELECT " + COL_JOB_NAME + ", " + COL_JOB_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_GROUP + " = ? ";
+
+    String INSERT_TRIGGER =
+            "INSERT INTO " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " ("
+            + COL_SCHEDULER_NAME + ", "
+            + COL_TRIGGER_NAME + ", "
+            + COL_TRIGGER_GROUP + ", "
+            + COL_JOB_NAME + ", "
+            + COL_JOB_GROUP + ", "
+            + COL_DESCRIPTION + ", "
+            + COL_NEXT_FIRE_TIME + ", "
+            + COL_PREV_FIRE_TIME + ", "
+            + COL_TRIGGER_STATE + ", "
+            + COL_TRIGGER_TYPE + ", "
+            + COL_START_TIME + ", "
+            + COL_END_TIME + ", "
+            + COL_CALENDAR_NAME + ", "
+            + COL_MISFIRE_INSTRUCTION + ", "
+            + COL_JOB_DATAMAP + ", "
+            + COL_PRIORITY
+            + " ) "
             + " VALUES(" + SCHED_NAME_SUBST + ", ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
-    String INSERT_SIMPLE_TRIGGER = "INSERT INTO "
-            + TABLE_PREFIX_SUBST + TABLE_SIMPLE_TRIGGERS + " ("
+    String INSERT_SIMPLE_TRIGGER =
+            "INSERT INTO " + TABLE_PREFIX_SUBST + TABLE_SIMPLE_TRIGGERS + " ("
             + COL_SCHEDULER_NAME + ", "
-            + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + ", "
-            + COL_REPEAT_COUNT + ", " + COL_REPEAT_INTERVAL + ", "
-            + COL_TIMES_TRIGGERED + ") " + " VALUES(" + SCHED_NAME_SUBST + ", ?, ?, ?, ?, ?)";
+            + COL_TRIGGER_NAME + ", "
+            + COL_TRIGGER_GROUP + ", "
+            + COL_REPEAT_COUNT + ", "
+            + COL_REPEAT_INTERVAL + ", "
+            + COL_TIMES_TRIGGERED
+            + " ) "
+            + " VALUES(" + SCHED_NAME_SUBST + ", ?, ?, ?, ?, ?)";
 
-    String INSERT_CRON_TRIGGER = "INSERT INTO "
-            + TABLE_PREFIX_SUBST + TABLE_CRON_TRIGGERS + " ("
+    String INSERT_CRON_TRIGGER =
+            "INSERT INTO " + TABLE_PREFIX_SUBST + TABLE_CRON_TRIGGERS + " ("
             + COL_SCHEDULER_NAME + ", "
-            + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + ", "
-            + COL_CRON_EXPRESSION + ", " + COL_TIME_ZONE_ID + ") "
+            + COL_TRIGGER_NAME + ", "
+            + COL_TRIGGER_GROUP + ", "
+            + COL_CRON_EXPRESSION + ", "
+            + COL_TIME_ZONE_ID
+            + " ) "
             + " VALUES(" + SCHED_NAME_SUBST + ", ?, ?, ?, ?)";
 
-    String INSERT_BLOB_TRIGGER = "INSERT INTO "
-            + TABLE_PREFIX_SUBST + TABLE_BLOB_TRIGGERS + " ("
+    String INSERT_BLOB_TRIGGER =
+            "INSERT INTO " + TABLE_PREFIX_SUBST + TABLE_BLOB_TRIGGERS + " ("
             + COL_SCHEDULER_NAME + ", "
-            + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + ", " + COL_BLOB
-            + ") " + " VALUES(" + SCHED_NAME_SUBST + ", ?, ?, ?)";
+            + COL_TRIGGER_NAME + ", "
+            + COL_TRIGGER_GROUP + ", "
+            + COL_BLOB
+            + " ) "
+            + " VALUES(" + SCHED_NAME_SUBST + ", ?, ?, ?)";
 
-    String UPDATE_TRIGGER_SKIP_DATA = "UPDATE " + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS + " SET " + COL_JOB_NAME + " = ?, "
-            + COL_JOB_GROUP + " = ?, " 
-            + COL_DESCRIPTION + " = ?, " + COL_NEXT_FIRE_TIME + " = ?, "
-            + COL_PREV_FIRE_TIME + " = ?, " + COL_TRIGGER_STATE + " = ?, "
-            + COL_TRIGGER_TYPE + " = ?, " + COL_START_TIME + " = ?, "
-            + COL_END_TIME + " = ?, " + COL_CALENDAR_NAME + " = ?, "
-            + COL_MISFIRE_INSTRUCTION + " = ?, " + COL_PRIORITY 
-            + " = ? WHERE " 
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME
-            + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String UPDATE_TRIGGER = "UPDATE " + TABLE_PREFIX_SUBST
-        + TABLE_TRIGGERS + " SET " + COL_JOB_NAME + " = ?, "
-        + COL_JOB_GROUP + " = ?, "
-        + COL_DESCRIPTION + " = ?, " + COL_NEXT_FIRE_TIME + " = ?, "
-        + COL_PREV_FIRE_TIME + " = ?, " + COL_TRIGGER_STATE + " = ?, "
-        + COL_TRIGGER_TYPE + " = ?, " + COL_START_TIME + " = ?, "
-        + COL_END_TIME + " = ?, " + COL_CALENDAR_NAME + " = ?, "
-        + COL_MISFIRE_INSTRUCTION + " = ?, " + COL_PRIORITY + " = ?, " 
-        + COL_JOB_DATAMAP + " = ? WHERE " 
-        + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-        + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-    
-    String UPDATE_SIMPLE_TRIGGER = "UPDATE "
-            + TABLE_PREFIX_SUBST + TABLE_SIMPLE_TRIGGERS + " SET "
-            + COL_REPEAT_COUNT + " = ?, " + COL_REPEAT_INTERVAL + " = ?, "
-            + COL_TIMES_TRIGGERED + " = ? WHERE " 
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME
-            + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String UPDATE_CRON_TRIGGER = "UPDATE "
-            + TABLE_PREFIX_SUBST + TABLE_CRON_TRIGGERS + " SET "
-            + COL_CRON_EXPRESSION + " = ?, " + COL_TIME_ZONE_ID  
-            + " = ? WHERE " 
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME
-            + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String UPDATE_BLOB_TRIGGER = "UPDATE "
-            + TABLE_PREFIX_SUBST + TABLE_BLOB_TRIGGERS + " SET " + COL_BLOB
-            + " = ? WHERE " 
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND "
-            + COL_TRIGGER_GROUP + " = ?";
-
-    String SELECT_TRIGGER_EXISTENCE = "SELECT "
-            + COL_TRIGGER_NAME + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+    String UPDATE_TRIGGER_SKIP_DATA =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " SET " + COL_JOB_NAME + " = ?, "
+            + COL_JOB_GROUP + " = ?, "
+            + COL_DESCRIPTION + " = ?, "
+            + COL_NEXT_FIRE_TIME + " = ?, "
+            + COL_PREV_FIRE_TIME + " = ?, "
+            + COL_TRIGGER_STATE + " = ?, "
+            + COL_TRIGGER_TYPE + " = ?, "
+            + COL_START_TIME + " = ?, "
+            + COL_END_TIME + " = ?, "
+            + COL_CALENDAR_NAME + " = ?, "
+            + COL_MISFIRE_INSTRUCTION + " = ?, "
+            + COL_PRIORITY + " = ? "
             + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP
-            + " = ?";
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String UPDATE_TRIGGER_STATE = "UPDATE "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " SET " + COL_TRIGGER_STATE
-            + " = ?" + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND "
-            + COL_TRIGGER_GROUP + " = ?";
+    String UPDATE_TRIGGER =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " SET " + COL_JOB_NAME + " = ?, "
+            + COL_JOB_GROUP + " = ?, "
+            + COL_DESCRIPTION + " = ?, "
+            + COL_NEXT_FIRE_TIME + " = ?, "
+            + COL_PREV_FIRE_TIME + " = ?, "
+            + COL_TRIGGER_STATE + " = ?, "
+            + COL_TRIGGER_TYPE + " = ?, "
+            + COL_START_TIME + " = ?, "
+            + COL_END_TIME + " = ?, "
+            + COL_CALENDAR_NAME + " = ?, "
+            + COL_MISFIRE_INSTRUCTION + " = ?, "
+            + COL_PRIORITY + " = ?, "
+            + COL_JOB_DATAMAP + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String UPDATE_TRIGGER_STATE_FROM_STATE = "UPDATE "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " SET " + COL_TRIGGER_STATE
-            + " = ?" + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND "
-            + COL_TRIGGER_GROUP + " = ? AND " + COL_TRIGGER_STATE + " = ?";
+    String UPDATE_SIMPLE_TRIGGER =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_SIMPLE_TRIGGERS
+            + " SET " + COL_REPEAT_COUNT + " = ?, "
+            + COL_REPEAT_INTERVAL + " = ?, "
+            + COL_TIMES_TRIGGERED + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String UPDATE_TRIGGER_GROUP_STATE_FROM_STATE = "UPDATE "
-            + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS
-            + " SET "
-            + COL_TRIGGER_STATE
-            + " = ?"
-            + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_GROUP
-            + " LIKE ? AND "
-            + COL_TRIGGER_STATE + " = ?";
+    String UPDATE_CRON_TRIGGER =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_CRON_TRIGGERS
+            + " SET " + COL_CRON_EXPRESSION + " = ?, "
+            + COL_TIME_ZONE_ID + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String UPDATE_TRIGGER_STATE_FROM_STATES = "UPDATE "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " SET " + COL_TRIGGER_STATE
-            + " = ?" + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND "
-            + COL_TRIGGER_GROUP + " = ? AND (" + COL_TRIGGER_STATE + " = ? OR "
-            + COL_TRIGGER_STATE + " = ? OR " + COL_TRIGGER_STATE + " = ?)";
+    String UPDATE_BLOB_TRIGGER =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_BLOB_TRIGGERS
+            + " SET " + COL_BLOB + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String UPDATE_TRIGGER_GROUP_STATE_FROM_STATES = "UPDATE "
-            + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS
-            + " SET "
-            + COL_TRIGGER_STATE
-            + " = ?"
-            + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_GROUP
-            + " LIKE ? AND ("
-            + COL_TRIGGER_STATE
-            + " = ? OR "
-            + COL_TRIGGER_STATE
-            + " = ? OR "
-            + COL_TRIGGER_STATE + " = ?)";
+    String SELECT_TRIGGER_EXISTENCE =
+            "SELECT " + COL_TRIGGER_NAME
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String UPDATE_JOB_TRIGGER_STATES = "UPDATE "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " SET " + COL_TRIGGER_STATE
-            + " = ? WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_JOB_NAME + " = ? AND " + COL_JOB_GROUP
-            + " = ?";
+    String UPDATE_TRIGGER_STATE =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " SET " + COL_TRIGGER_STATE + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String UPDATE_JOB_TRIGGER_STATES_FROM_OTHER_STATE = "UPDATE "
-            + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS
-            + " SET "
-            + COL_TRIGGER_STATE
-            + " = ? WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_JOB_NAME
-            + " = ? AND "
+    String UPDATE_TRIGGER_STATE_FROM_STATE =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " SET " + COL_TRIGGER_STATE + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? "
+            + " AND " + COL_TRIGGER_STATE + " = ? ";
+
+    String UPDATE_TRIGGER_GROUP_STATE_FROM_STATE =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " SET " + COL_TRIGGER_STATE + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_GROUP + " LIKE ? "
+            + " AND " + COL_TRIGGER_STATE + " = ? ";
+
+    String UPDATE_TRIGGER_STATE_FROM_STATES =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " SET " + COL_TRIGGER_STATE + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? "
+            + " AND (" + COL_TRIGGER_STATE + " = ? "
+            + " OR " + COL_TRIGGER_STATE + " = ? "
+            + " OR " + COL_TRIGGER_STATE + " = ? "
+            + " )";
+
+    String UPDATE_TRIGGER_GROUP_STATE_FROM_STATES =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " SET " + COL_TRIGGER_STATE + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_GROUP + " LIKE ? "
+            + " AND (" + COL_TRIGGER_STATE + " = ? "
+            + " OR " + COL_TRIGGER_STATE + " = ? "
+            + " OR " + COL_TRIGGER_STATE + " = ? "
+            + " )";
+
+    String UPDATE_JOB_TRIGGER_STATES =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " SET " + COL_TRIGGER_STATE + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? "
+            + " AND " + COL_JOB_GROUP + " = ? ";
+
+    String UPDATE_JOB_TRIGGER_STATES_FROM_OTHER_STATE =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " SET " + COL_TRIGGER_STATE + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? "
+            + " AND " + COL_JOB_GROUP + " = ? "
+            + " AND " + COL_TRIGGER_STATE + " = ? ";
+
+    String DELETE_SIMPLE_TRIGGER =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_SIMPLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
+
+    String DELETE_CRON_TRIGGER =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_CRON_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
+
+    String DELETE_BLOB_TRIGGER =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_BLOB_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
+
+    String DELETE_TRIGGER =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
+
+    String SELECT_NUM_TRIGGERS_FOR_JOB =
+            "SELECT COUNT(" + COL_TRIGGER_NAME + ") "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? "
+            + " AND " + COL_JOB_GROUP + " = ? ";
+
+    String SELECT_JOB_FOR_TRIGGER =
+            "SELECT J." + COL_JOB_NAME + ","
+            + " J." + COL_JOB_GROUP + ","
+            + " J." + COL_IS_DURABLE + ","
+            + " J." + COL_JOB_CLASS + ","
+            + " J." + COL_REQUESTS_RECOVERY
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " T, "
+            + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " J "
+            + " WHERE T." + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND J." + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND T." + COL_TRIGGER_NAME + " = ? "
+            + " AND T." + COL_TRIGGER_GROUP + " = ? "
+            + " AND T." + COL_JOB_NAME + " = J." + COL_JOB_NAME
+            + " AND T." + COL_JOB_GROUP + " = J." + COL_JOB_GROUP;
+
+    String SELECT_TRIGGER =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
+
+    String SELECT_TRIGGER_DATA =
+            "SELECT " + COL_JOB_DATAMAP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
+
+    String SELECT_TRIGGER_STATE =
+            "SELECT " + COL_TRIGGER_STATE
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
+
+    String SELECT_TRIGGER_STATUS =
+            "SELECT " + COL_TRIGGER_STATE + ", "
+            + COL_NEXT_FIRE_TIME + ", "
+            + COL_JOB_NAME + ", "
             + COL_JOB_GROUP
-            + " = ? AND " + COL_TRIGGER_STATE + " = ?";
-
-    String DELETE_SIMPLE_TRIGGER = "DELETE FROM "
-            + TABLE_PREFIX_SUBST + TABLE_SIMPLE_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String DELETE_CRON_TRIGGER = "DELETE FROM "
-            + TABLE_PREFIX_SUBST + TABLE_CRON_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String DELETE_BLOB_TRIGGER = "DELETE FROM "
-            + TABLE_PREFIX_SUBST + TABLE_BLOB_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String DELETE_TRIGGER = "DELETE FROM "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String SELECT_NUM_TRIGGERS_FOR_JOB = "SELECT COUNT("
-            + COL_TRIGGER_NAME + ") FROM " + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_JOB_NAME + " = ? AND "
-            + COL_JOB_GROUP + " = ?";
-
-    String SELECT_JOB_FOR_TRIGGER = "SELECT J."
-            + COL_JOB_NAME + ", J." + COL_JOB_GROUP + ", J." + COL_IS_DURABLE
-            + ", J." + COL_JOB_CLASS + ", J." + COL_REQUESTS_RECOVERY + " FROM " + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS + " T, " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS
-            + " J WHERE T." + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST 
-            + " AND J." + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST 
-            + " AND T." + COL_TRIGGER_NAME + " = ? AND T."
-            + COL_TRIGGER_GROUP + " = ? AND T." + COL_JOB_NAME + " = J."
-            + COL_JOB_NAME + " AND T." + COL_JOB_GROUP + " = J."
-            + COL_JOB_GROUP;
-
-    String SELECT_TRIGGER = "SELECT * FROM "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String SELECT_TRIGGER_DATA = "SELECT " + 
-            COL_JOB_DATAMAP + " FROM "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-        
-    String SELECT_TRIGGER_STATE = "SELECT "
-            + COL_TRIGGER_STATE + " FROM " + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND "
-            + COL_TRIGGER_GROUP + " = ?";
-
-    String SELECT_TRIGGER_STATUS = "SELECT "
-            + COL_TRIGGER_STATE + ", " + COL_NEXT_FIRE_TIME + ", "
-            + COL_JOB_NAME + ", " + COL_JOB_GROUP + " FROM "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String SELECT_SIMPLE_TRIGGER = "SELECT *" + " FROM "
-            + TABLE_PREFIX_SUBST + TABLE_SIMPLE_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String SELECT_CRON_TRIGGER = "SELECT *" + " FROM "
-            + TABLE_PREFIX_SUBST + TABLE_CRON_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String SELECT_BLOB_TRIGGER = "SELECT *" + " FROM "
-            + TABLE_PREFIX_SUBST + TABLE_BLOB_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String SELECT_NUM_TRIGGERS = "SELECT COUNT("
-            + COL_TRIGGER_NAME + ") " + " FROM " + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
-
-    String SELECT_NUM_TRIGGERS_IN_GROUP = "SELECT COUNT("
-            + COL_TRIGGER_NAME + ") " + " FROM " + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_GROUP + " = ?";
-
-    String SELECT_TRIGGER_GROUPS = "SELECT DISTINCT("
-            + COL_TRIGGER_GROUP + ") FROM " + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
-
-    String SELECT_TRIGGER_GROUPS_FILTERED = "SELECT DISTINCT("
-            + COL_TRIGGER_GROUP + ") FROM " + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST + " AND " + COL_TRIGGER_GROUP + " LIKE ?";
-
-    String SELECT_TRIGGERS_IN_GROUP_LIKE = "SELECT "
-            + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
             + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_GROUP + " LIKE ?";
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String SELECT_TRIGGERS_IN_GROUP = "SELECT "
-            + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+    String SELECT_SIMPLE_TRIGGER =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_SIMPLE_TRIGGERS
             + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_GROUP + " = ?";
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String INSERT_CALENDAR = "INSERT INTO "
-            + TABLE_PREFIX_SUBST + TABLE_CALENDARS + " (" + COL_SCHEDULER_NAME + ", " + COL_CALENDAR_NAME
-            + ", " + COL_CALENDAR + ") " + " VALUES(" + SCHED_NAME_SUBST + ", ?, ?)";
+    String SELECT_CRON_TRIGGER =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_CRON_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String UPDATE_CALENDAR = "UPDATE " + TABLE_PREFIX_SUBST
-            + TABLE_CALENDARS + " SET " + COL_CALENDAR + " = ? " + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_CALENDAR_NAME + " = ?";
+    String SELECT_BLOB_TRIGGER =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_BLOB_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String SELECT_CALENDAR_EXISTENCE = "SELECT "
-            + COL_CALENDAR_NAME + " FROM " + TABLE_PREFIX_SUBST
-            + TABLE_CALENDARS + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_CALENDAR_NAME + " = ?";
+    String SELECT_NUM_TRIGGERS =
+            "SELECT COUNT(" + COL_TRIGGER_NAME + ") "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
 
-    String SELECT_CALENDAR = "SELECT *" + " FROM "
-            + TABLE_PREFIX_SUBST + TABLE_CALENDARS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_CALENDAR_NAME + " = ?";
+    String SELECT_NUM_TRIGGERS_IN_GROUP =
+            "SELECT COUNT(" + COL_TRIGGER_NAME + ") "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String SELECT_REFERENCED_CALENDAR = "SELECT "
-            + COL_CALENDAR_NAME + " FROM " + TABLE_PREFIX_SUBST
-            + TABLE_TRIGGERS + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_CALENDAR_NAME + " = ?";
+    String SELECT_TRIGGER_GROUPS =
+            "SELECT DISTINCT(" + COL_TRIGGER_GROUP + ") "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
 
-    String DELETE_CALENDAR = "DELETE FROM "
-            + TABLE_PREFIX_SUBST + TABLE_CALENDARS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_CALENDAR_NAME + " = ?";
+    String SELECT_TRIGGER_GROUPS_FILTERED =
+            "SELECT DISTINCT(" + COL_TRIGGER_GROUP + ") "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_GROUP + " LIKE ? ";
 
-    String SELECT_NUM_CALENDARS = "SELECT COUNT("
-            + COL_CALENDAR_NAME + ") " + " FROM " + TABLE_PREFIX_SUBST
-            + TABLE_CALENDARS + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+    String SELECT_TRIGGERS_IN_GROUP_LIKE =
+            "SELECT " + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_GROUP + " LIKE ? ";
 
-    String SELECT_CALENDARS = "SELECT " + COL_CALENDAR_NAME
+    String SELECT_TRIGGERS_IN_GROUP =
+            "SELECT " + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
+
+    String INSERT_CALENDAR =
+            "INSERT INTO " + TABLE_PREFIX_SUBST + TABLE_CALENDARS + " ("
+            + COL_SCHEDULER_NAME + ", "
+            + COL_CALENDAR_NAME + ", "
+            + COL_CALENDAR
+            + ") "
+            + " VALUES(" + SCHED_NAME_SUBST + ", ?, ?)";
+
+    String UPDATE_CALENDAR =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_CALENDARS
+            + " SET " + COL_CALENDAR + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_CALENDAR_NAME + " = ? ";
+
+    String SELECT_CALENDAR_EXISTENCE =
+            "SELECT " + COL_CALENDAR_NAME
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_CALENDARS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_CALENDAR_NAME + " = ? ";
+
+    String SELECT_CALENDAR =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_CALENDARS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_CALENDAR_NAME + " = ? ";
+
+    String SELECT_REFERENCED_CALENDAR =
+            "SELECT " + COL_CALENDAR_NAME
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_CALENDAR_NAME + " = ? ";
+
+    String DELETE_CALENDAR =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_CALENDARS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_CALENDAR_NAME + " = ? ";
+
+    String SELECT_NUM_CALENDARS =
+            "SELECT COUNT(" + COL_CALENDAR_NAME + ") "
             + " FROM " + TABLE_PREFIX_SUBST + TABLE_CALENDARS
             + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
 
-    String SELECT_NEXT_FIRE_TIME = "SELECT MIN("
-            + COL_NEXT_FIRE_TIME + ") AS " + ALIAS_COL_NEXT_FIRE_TIME
-            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_STATE + " = ? AND " + COL_NEXT_FIRE_TIME + " >= 0";
+    String SELECT_CALENDARS =
+            "SELECT " + COL_CALENDAR_NAME
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_CALENDARS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
 
-    String SELECT_TRIGGER_FOR_FIRE_TIME = "SELECT "
-            + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + " FROM "
-            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_STATE + " = ? AND " + COL_NEXT_FIRE_TIME + " = ?";
+    String SELECT_NEXT_FIRE_TIME =
+            "SELECT MIN(" + COL_NEXT_FIRE_TIME + ") AS " + ALIAS_COL_NEXT_FIRE_TIME
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_STATE + " = ? "
+            + " AND " + COL_NEXT_FIRE_TIME + " >= 0";
 
-    String SELECT_NEXT_TRIGGER_TO_ACQUIRE = "SELECT "
-        + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + ", "
-        + COL_NEXT_FIRE_TIME + ", " + COL_PRIORITY + " FROM "
-        + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
-        + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-        + " AND " + COL_TRIGGER_STATE + " = ? AND " + COL_NEXT_FIRE_TIME + " <= ? " 
-        + "AND (" + COL_MISFIRE_INSTRUCTION + " = -1 OR (" +COL_MISFIRE_INSTRUCTION+ " <> -1 AND "+ COL_NEXT_FIRE_TIME + " >= ?)) "
-        + "ORDER BY "+ COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
-    
-    
-    String INSERT_FIRED_TRIGGER = "INSERT INTO "
-            + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS + " (" + COL_SCHEDULER_NAME + ", " + COL_ENTRY_ID
-            + ", " + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + ", "
+    String SELECT_TRIGGER_FOR_FIRE_TIME =
+            "SELECT " + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_STATE + " = ? "
+            + " AND " + COL_NEXT_FIRE_TIME + " = ? ";
+
+    String SELECT_NEXT_TRIGGER_TO_ACQUIRE =
+            "SELECT " + COL_TRIGGER_NAME + ", "
+            + COL_TRIGGER_GROUP + ", "
+            + COL_NEXT_FIRE_TIME + ", "
+            + COL_PRIORITY
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_STATE + " = ? AND " + COL_NEXT_FIRE_TIME + " <= ? "
+            + "AND ( " + COL_MISFIRE_INSTRUCTION + " = -1 "
+            + " OR ( " + COL_MISFIRE_INSTRUCTION + " <> -1 AND " + COL_NEXT_FIRE_TIME + " >= ?)"
+            + ") "
+            + "ORDER BY "+ COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
+
+    String INSERT_FIRED_TRIGGER =
+            "INSERT INTO " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS + " ("
+            + COL_SCHEDULER_NAME + ", "
+            + COL_ENTRY_ID + ", "
+            + COL_TRIGGER_NAME + ", "
+            + COL_TRIGGER_GROUP + ", "
             + COL_INSTANCE_NAME + ", "
-            + COL_FIRED_TIME + ", " + COL_SCHED_TIME + ", " + COL_ENTRY_STATE + ", " + COL_JOB_NAME
-            + ", " + COL_JOB_GROUP + ", " + COL_IS_NONCONCURRENT + ", "
-            + COL_REQUESTS_RECOVERY + ", " + COL_PRIORITY
+            + COL_FIRED_TIME + ", "
+            + COL_SCHED_TIME + ", "
+            + COL_ENTRY_STATE + ", "
+            + COL_JOB_NAME + ", "
+            + COL_JOB_GROUP + ", "
+            + COL_IS_NONCONCURRENT + ", "
+            + COL_REQUESTS_RECOVERY + ", "
+            + COL_PRIORITY
             + ") VALUES(" + SCHED_NAME_SUBST + ", ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
-    String UPDATE_FIRED_TRIGGER = "UPDATE "
-        + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS + " SET " 
-        + COL_INSTANCE_NAME + " = ?, "
-        + COL_FIRED_TIME + " = ?, " + COL_SCHED_TIME + " = ?, " + COL_ENTRY_STATE + " = ?, " + COL_JOB_NAME
-        + " = ?, " + COL_JOB_GROUP + " = ?, " + COL_IS_NONCONCURRENT + " = ?, "
-        + COL_REQUESTS_RECOVERY + " = ? WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-        + " AND " + COL_ENTRY_ID + " = ?";
+    String UPDATE_FIRED_TRIGGER =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " SET " + COL_INSTANCE_NAME + " = ?, "
+            + COL_FIRED_TIME + " = ?, "
+            + COL_SCHED_TIME + " = ?, "
+            + COL_ENTRY_STATE + " = ?, "
+            + COL_JOB_NAME + " = ?, "
+            + COL_JOB_GROUP + " = ?, "
+            + COL_IS_NONCONCURRENT + " = ?, "
+            + COL_REQUESTS_RECOVERY + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_ENTRY_ID + " = ? ";
 
-    String SELECT_INSTANCES_FIRED_TRIGGERS = "SELECT * FROM "
-            + TABLE_PREFIX_SUBST
-            + TABLE_FIRED_TRIGGERS
-            + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_INSTANCE_NAME + " = ?";
+    String SELECT_INSTANCES_FIRED_TRIGGERS =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_INSTANCE_NAME + " = ? ";
 
-    String SELECT_INSTANCES_RECOVERABLE_FIRED_TRIGGERS = "SELECT * FROM "
-            + TABLE_PREFIX_SUBST
-            + TABLE_FIRED_TRIGGERS
-            + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_INSTANCE_NAME + " = ? AND " + COL_REQUESTS_RECOVERY + " = ?";
+    String SELECT_INSTANCES_RECOVERABLE_FIRED_TRIGGERS =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_INSTANCE_NAME + " = ? "
+            + " AND " + COL_REQUESTS_RECOVERY + " = ? ";
 
-    String SELECT_JOB_EXECUTION_COUNT = "SELECT COUNT("
-            + COL_TRIGGER_NAME + ") FROM " + TABLE_PREFIX_SUBST
-            + TABLE_FIRED_TRIGGERS + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_JOB_NAME + " = ? AND "
-            + COL_JOB_GROUP + " = ?";
+    String SELECT_JOB_EXECUTION_COUNT =
+            "SELECT COUNT(" + COL_TRIGGER_NAME + ") "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? "
+            + " AND " + COL_JOB_GROUP + " = ? ";
 
-    String SELECT_FIRED_TRIGGERS = "SELECT * FROM "
-            + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+    String SELECT_FIRED_TRIGGERS =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
             + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
 
-    String SELECT_FIRED_TRIGGER = "SELECT * FROM "
-            + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_NAME + " = ? AND " + COL_TRIGGER_GROUP + " = ?";
+    String SELECT_FIRED_TRIGGER =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_NAME + " = ? "
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String SELECT_FIRED_TRIGGER_GROUP = "SELECT * FROM "
-            + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_GROUP + " = ?";
+    String SELECT_FIRED_TRIGGER_GROUP =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String SELECT_FIRED_TRIGGERS_OF_JOB = "SELECT * FROM "
-            + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_JOB_NAME + " = ? AND " + COL_JOB_GROUP + " = ?";
+    String SELECT_FIRED_TRIGGERS_OF_JOB =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? AND " + COL_JOB_GROUP + " = ? ";
 
-    String SELECT_FIRED_TRIGGERS_OF_JOB_GROUP = "SELECT * FROM "
-            + TABLE_PREFIX_SUBST
-            + TABLE_FIRED_TRIGGERS
-            + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_JOB_GROUP + " = ?";
+    String SELECT_FIRED_TRIGGERS_OF_JOB_GROUP =
+            "SELECT * "
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_GROUP + " = ? ";
 
-    String DELETE_FIRED_TRIGGER = "DELETE FROM "
-            + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_ENTRY_ID + " = ?";
+    String DELETE_FIRED_TRIGGER =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_ENTRY_ID + " = ? ";
 
-    String DELETE_INSTANCES_FIRED_TRIGGERS = "DELETE FROM "
-            + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_INSTANCE_NAME + " = ?";
+    String DELETE_INSTANCES_FIRED_TRIGGERS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_INSTANCE_NAME + " = ? ";
 
-    String DELETE_NO_RECOVERY_FIRED_TRIGGERS = "DELETE FROM "
-            + TABLE_PREFIX_SUBST
-            + TABLE_FIRED_TRIGGERS
-            + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_INSTANCE_NAME + " = ?" + COL_REQUESTS_RECOVERY + " = ?";
+    String DELETE_NO_RECOVERY_FIRED_TRIGGERS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_INSTANCE_NAME + " = ? " + COL_REQUESTS_RECOVERY + " = ? ";
 
-    String DELETE_ALL_SIMPLE_TRIGGERS = "DELETE FROM " + TABLE_PREFIX_SUBST + "SIMPLE_TRIGGERS " + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
-    String DELETE_ALL_SIMPROP_TRIGGERS = "DELETE FROM " + TABLE_PREFIX_SUBST + "SIMPROP_TRIGGERS " + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
-    String DELETE_ALL_CRON_TRIGGERS = "DELETE FROM " + TABLE_PREFIX_SUBST + "CRON_TRIGGERS" + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
-    String DELETE_ALL_BLOB_TRIGGERS = "DELETE FROM " + TABLE_PREFIX_SUBST + "BLOB_TRIGGERS" + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
-    String DELETE_ALL_TRIGGERS = "DELETE FROM " + TABLE_PREFIX_SUBST + "TRIGGERS" + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
-    String DELETE_ALL_JOB_DETAILS = "DELETE FROM " + TABLE_PREFIX_SUBST + "JOB_DETAILS" + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
-    String DELETE_ALL_CALENDARS = "DELETE FROM " + TABLE_PREFIX_SUBST + "CALENDARS" + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
-    String DELETE_ALL_PAUSED_TRIGGER_GRPS = "DELETE FROM " + TABLE_PREFIX_SUBST + "PAUSED_TRIGGER_GRPS" + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
-    
-    String SELECT_FIRED_TRIGGER_INSTANCE_NAMES = 
-            "SELECT DISTINCT " + COL_INSTANCE_NAME + " FROM "
-            + TABLE_PREFIX_SUBST
-            + TABLE_FIRED_TRIGGERS
+    String DELETE_ALL_SIMPLE_TRIGGERS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + "SIMPLE_TRIGGERS "
             + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
-    
-    String INSERT_SCHEDULER_STATE = "INSERT INTO "
-            + TABLE_PREFIX_SUBST + TABLE_SCHEDULER_STATE + " ("
+
+    String DELETE_ALL_SIMPROP_TRIGGERS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + "SIMPROP_TRIGGERS "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+
+    String DELETE_ALL_CRON_TRIGGERS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + "CRON_TRIGGERS"
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+
+    String DELETE_ALL_BLOB_TRIGGERS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + "BLOB_TRIGGERS"
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+
+    String DELETE_ALL_TRIGGERS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + "TRIGGERS"
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+
+    String DELETE_ALL_JOB_DETAILS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + "JOB_DETAILS"
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+
+    String DELETE_ALL_CALENDARS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + "CALENDARS"
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+
+    String DELETE_ALL_PAUSED_TRIGGER_GRPS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + "PAUSED_TRIGGER_GRPS"
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+
+    String SELECT_FIRED_TRIGGER_INSTANCE_NAMES =
+            "SELECT DISTINCT " + COL_INSTANCE_NAME
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+
+    String INSERT_SCHEDULER_STATE =
+            "INSERT INTO " + TABLE_PREFIX_SUBST + TABLE_SCHEDULER_STATE + " ("
             + COL_SCHEDULER_NAME + ", "
-            + COL_INSTANCE_NAME + ", " + COL_LAST_CHECKIN_TIME + ", "
-            + COL_CHECKIN_INTERVAL + ") VALUES(" + SCHED_NAME_SUBST + ", ?, ?, ?)";
+            + COL_INSTANCE_NAME + ", "
+            + COL_LAST_CHECKIN_TIME + ", "
+            + COL_CHECKIN_INTERVAL
+            + " ) "
+            + " VALUES(" + SCHED_NAME_SUBST + ", ?, ?, ?)";
 
-    String SELECT_SCHEDULER_STATE = "SELECT * FROM "
-            + TABLE_PREFIX_SUBST + TABLE_SCHEDULER_STATE + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_INSTANCE_NAME + " = ?";
+    String SELECT_SCHEDULER_STATE =
+            "SELECT * FROM " + TABLE_PREFIX_SUBST + TABLE_SCHEDULER_STATE
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_INSTANCE_NAME + " = ? ";
 
-    String SELECT_SCHEDULER_STATES = "SELECT * FROM "
-            + TABLE_PREFIX_SUBST + TABLE_SCHEDULER_STATE
+    String SELECT_SCHEDULER_STATES =
+            "SELECT * FROM " + TABLE_PREFIX_SUBST + TABLE_SCHEDULER_STATE
             + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
 
-    String DELETE_SCHEDULER_STATE = "DELETE FROM "
-        + TABLE_PREFIX_SUBST + TABLE_SCHEDULER_STATE + " WHERE "
-        + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-        + " AND " + COL_INSTANCE_NAME + " = ?";
+    String DELETE_SCHEDULER_STATE =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_SCHEDULER_STATE
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_INSTANCE_NAME + " = ? ";
 
-    String UPDATE_SCHEDULER_STATE = "UPDATE "
-        + TABLE_PREFIX_SUBST + TABLE_SCHEDULER_STATE + " SET " 
-        + COL_LAST_CHECKIN_TIME + " = ? WHERE "
-        + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-        + " AND " + COL_INSTANCE_NAME + " = ?";
+    String UPDATE_SCHEDULER_STATE =
+            "UPDATE " + TABLE_PREFIX_SUBST + TABLE_SCHEDULER_STATE
+            + " SET " + COL_LAST_CHECKIN_TIME + " = ? "
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_INSTANCE_NAME + " = ? ";
 
-    String INSERT_PAUSED_TRIGGER_GROUP = "INSERT INTO "
-            + TABLE_PREFIX_SUBST + TABLE_PAUSED_TRIGGERS + " ("
-            + COL_SCHEDULER_NAME + ", "
-            + COL_TRIGGER_GROUP + ") VALUES(" + SCHED_NAME_SUBST + ", ?)";
+    String INSERT_PAUSED_TRIGGER_GROUP =
+            "INSERT INTO " + TABLE_PREFIX_SUBST + TABLE_PAUSED_TRIGGERS
+            + " (" + COL_SCHEDULER_NAME + ", " + COL_TRIGGER_GROUP + ") "
+            + " VALUES(" + SCHED_NAME_SUBST + ", ?)";
 
-    String SELECT_PAUSED_TRIGGER_GROUP = "SELECT "
-            + COL_TRIGGER_GROUP + " FROM " + TABLE_PREFIX_SUBST
-            + TABLE_PAUSED_TRIGGERS + " WHERE " 
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_GROUP + " = ?";
+    String SELECT_PAUSED_TRIGGER_GROUP =
+            "SELECT " + COL_TRIGGER_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_PAUSED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_GROUP + " = ? ";
 
-    String SELECT_PAUSED_TRIGGER_GROUPS = "SELECT "
-        + COL_TRIGGER_GROUP + " FROM " + TABLE_PREFIX_SUBST
-        + TABLE_PAUSED_TRIGGERS
-        + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+    String SELECT_PAUSED_TRIGGER_GROUPS =
+            "SELECT " + COL_TRIGGER_GROUP
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_PAUSED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
 
-    String DELETE_PAUSED_TRIGGER_GROUP = "DELETE FROM "
-            + TABLE_PREFIX_SUBST + TABLE_PAUSED_TRIGGERS + " WHERE "
-            + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_GROUP + " LIKE ?";
+    String DELETE_PAUSED_TRIGGER_GROUP =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_PAUSED_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_TRIGGER_GROUP + " LIKE ? ";
 
-    String DELETE_PAUSED_TRIGGER_GROUPS = "DELETE FROM "
-            + TABLE_PREFIX_SUBST + TABLE_PAUSED_TRIGGERS
+    String DELETE_PAUSED_TRIGGER_GROUPS =
+            "DELETE FROM " + TABLE_PREFIX_SUBST + TABLE_PAUSED_TRIGGERS
             + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
 
     //  CREATE TABLE qrtz_scheduler_state(INSTANCE_NAME VARCHAR2(80) NOT NULL,
@@ -668,4 +785,4 @@ public interface StdJDBCConstants extends Constants {
 
 }
 
-// EOF
+

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
@@ -582,10 +582,7 @@ public interface StdJDBCConstants extends Constants {
 
     String SELECT_NEXT_TRIGGER_TO_ACQUIRE =
             "SELECT " 
-            + "  T." + COL_TRIGGER_NAME + ", "
-            + "  T." + COL_TRIGGER_GROUP + ", "
-            + "  T." + COL_NEXT_FIRE_TIME + ", "
-            + "  T." + COL_PRIORITY + ", "
+            + "  T.*, "
             + "  J." + COL_IS_NONCONCURRENT
             + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " T "
             + " INNER JOIN " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " J ON ( "

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
@@ -581,16 +581,28 @@ public interface StdJDBCConstants extends Constants {
             + " AND " + COL_NEXT_FIRE_TIME + " = ? ";
 
     String SELECT_NEXT_TRIGGER_TO_ACQUIRE =
-            "SELECT " + COL_TRIGGER_NAME + ", "
-            + COL_TRIGGER_GROUP + ", "
-            + COL_NEXT_FIRE_TIME + ", "
-            + COL_PRIORITY
-            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
-            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
-            + " AND " + COL_TRIGGER_STATE + " = ? AND " + COL_NEXT_FIRE_TIME + " <= ? "
-            + "AND ( " + COL_MISFIRE_INSTRUCTION + " = -1 "
-            + " OR ( " + COL_MISFIRE_INSTRUCTION + " <> -1 AND " + COL_NEXT_FIRE_TIME + " >= ?)"
-            + ") "
+            "SELECT " 
+            + "  T." + COL_TRIGGER_NAME + ", "
+            + "  T." + COL_TRIGGER_GROUP + ", "
+            + "  T." + COL_NEXT_FIRE_TIME + ", "
+            + "  T." + COL_PRIORITY + ", "
+            + "  J." + COL_IS_NONCONCURRENT
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " T "
+            + " INNER JOIN " + TABLE_PREFIX_SUBST + TABLE_JOB_DETAILS + " J ON ( "
+            + "  T." + COL_SCHEDULER_NAME + " = J." + COL_SCHEDULER_NAME 
+            + "  AND T." + COL_JOB_NAME + " = J." + COL_JOB_NAME
+            + "  AND T." + COL_JOB_GROUP + " = J." + COL_JOB_GROUP
+            + " ) "
+            + " WHERE T." + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND T." + COL_TRIGGER_STATE + " = ? "
+            + " AND T." + COL_NEXT_FIRE_TIME + " <= ? "
+            + " AND ( "
+            + "   T." + COL_MISFIRE_INSTRUCTION + " = -1 "
+            + "   OR ( "
+            + "     T." + COL_MISFIRE_INSTRUCTION + " <> -1 "
+            + "     AND T." + COL_NEXT_FIRE_TIME + " >= ?"
+            + "   ) "
+            + " ) "
             + "ORDER BY "+ COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
 
     String INSERT_FIRED_TRIGGER =

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
@@ -2567,7 +2567,7 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
      * 
      * @deprecated - This remained for compatibility reason. Use {@link #selectTriggerToAcquire(Connection, long, long, int)} instead. 
      */
-    public List<TriggerKey> selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan)
+    public List<TriggerToAcquireDTO> selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan)
             throws SQLException {
         // This old API used to always return 1 trigger.
         return selectTriggerToAcquire(conn, noLaterThan, noEarlierThan, 1);
@@ -2590,11 +2590,11 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
      *          
      * @return A (never null, possibly empty) list of the identifiers (Key objects) of the next triggers to be fired.
      */
-    public List<TriggerKey> selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan, int maxCount)
+    public List<TriggerToAcquireDTO> selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan, int maxCount)
         throws SQLException {
         PreparedStatement ps = null;
         ResultSet rs = null;
-        List<TriggerKey> nextTriggers = new LinkedList<TriggerKey>();
+        List<TriggerToAcquireDTO> nextTriggers = new LinkedList<>();
         try {
             ps = conn.prepareStatement(rtp(SELECT_NEXT_TRIGGER_TO_ACQUIRE));
             
@@ -2613,9 +2613,10 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
             rs = ps.executeQuery();
             
             while (rs.next() && nextTriggers.size() < maxCount) {
-                nextTriggers.add(triggerKey(
+                nextTriggers.add(new TriggerToAcquireDTO(
                         rs.getString(COL_TRIGGER_NAME),
-                        rs.getString(COL_TRIGGER_GROUP)));
+                        rs.getString(COL_TRIGGER_GROUP),
+                        rs.getBoolean(COL_IS_NONCONCURRENT)));
             }
             
             return nextTriggers;

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/TriggerToAcquireDTO.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/TriggerToAcquireDTO.java
@@ -1,26 +1,23 @@
 package org.quartz.impl.jdbcjobstore;
 
+import org.quartz.spi.OperableTrigger;
+
 public class TriggerToAcquireDTO {
 
-    private final String name;
-    private final String group;
+    private final OperableTrigger trigger;
     private final boolean concurrentExecutionDisallowed;
-    
-    public TriggerToAcquireDTO(String name, String group, boolean concurrentExecutionDisallowed) {
-        this.name = name;
-        this.group = group;
+
+    public TriggerToAcquireDTO(OperableTrigger trigger, boolean concurrentExecutionDisallowed) {
+        this.trigger = trigger;
         this.concurrentExecutionDisallowed = concurrentExecutionDisallowed;
     }
-    
-    public String getName() {
-        return name;
+
+    public OperableTrigger getTrigger() {
+        return trigger;
     }
-    
-    public String getGroup() {
-        return group;
-    }
-    
+
     public boolean getConcurrentExecutionDisallowed() {
         return concurrentExecutionDisallowed;
     }
+
 }

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/TriggerToAcquireDTO.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/TriggerToAcquireDTO.java
@@ -1,0 +1,26 @@
+package org.quartz.impl.jdbcjobstore;
+
+public class TriggerToAcquireDTO {
+
+    private final String name;
+    private final String group;
+    private final boolean concurrentExecutionDisallowed;
+    
+    public TriggerToAcquireDTO(String name, String group, boolean concurrentExecutionDisallowed) {
+        this.name = name;
+        this.group = group;
+        this.concurrentExecutionDisallowed = concurrentExecutionDisallowed;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public String getGroup() {
+        return group;
+    }
+    
+    public boolean getConcurrentExecutionDisallowed() {
+        return concurrentExecutionDisallowed;
+    }
+}

--- a/quartz-core/src/test/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegateTest.java
+++ b/quartz-core/src/test/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegateTest.java
@@ -151,7 +151,7 @@ public class StdJDBCDelegateTest extends TestCase {
         when(preparedStatement.executeQuery()).thenReturn(resultSet);
 
         when(resultSet.next()).thenReturn(true);
-        when(resultSet.getString(anyString())).thenReturn("test");
+        when(resultSet.getString(anyString())).thenReturn("BLOB");
 
         List<TriggerToAcquireDTO> triggerKeys = 
                 jdbcDelegate.selectTriggerToAcquire(conn, Long.MAX_VALUE, Long.MIN_VALUE, 10);

--- a/quartz-core/src/test/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegateTest.java
+++ b/quartz-core/src/test/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegateTest.java
@@ -153,7 +153,8 @@ public class StdJDBCDelegateTest extends TestCase {
         when(resultSet.next()).thenReturn(true);
         when(resultSet.getString(anyString())).thenReturn("test");
 
-        List<TriggerKey> triggerKeys = jdbcDelegate.selectTriggerToAcquire(conn, Long.MAX_VALUE, Long.MIN_VALUE, 10);
+        List<TriggerToAcquireDTO> triggerKeys = 
+                jdbcDelegate.selectTriggerToAcquire(conn, Long.MAX_VALUE, Long.MIN_VALUE, 10);
 
         assertThat(triggerKeys, iterableWithSize(10));
     }


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
Fix N+1 problem in scheduler
Load triggers with single query instead of doing
1. load trigger keys to acquire
2. load trigger for each trigger key in a loop
3. load job for each trigger in a loop

## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

