### PR TITLE
Interrupt the scheduler thread when shutdown is occurring, in case it …

### DIFF
--- a/quartz-core/src/main/java/org/quartz/core/QuartzSchedulerThread.java
+++ b/quartz-core/src/main/java/org/quartz/core/QuartzSchedulerThread.java
@@ -166,6 +166,7 @@ public class QuartzSchedulerThread extends Thread {
     void halt(boolean wait) {
         synchronized (sigLock) {
             halted.set(true);
+            this.interrupt();
 
             if (paused) {
                 sigLock.notifyAll();
@@ -276,6 +277,11 @@ public class QuartzSchedulerThread extends Thread {
                 }
 
                 int availThreadCount = qsRsrcs.getThreadPool().blockForAvailableThreads();
+                synchronized (sigLock) {
+                    if (halted.get()) {
+                        break;
+                    }
+                }
                 if(availThreadCount > 0) { // will always be true, due to semantics of blockForAvailableThreads...
 
                     List<OperableTrigger> triggers;

--- a/quartz-core/src/main/java/org/quartz/core/QuartzSchedulerThread.java
+++ b/quartz-core/src/main/java/org/quartz/core/QuartzSchedulerThread.java
@@ -166,7 +166,6 @@ public class QuartzSchedulerThread extends Thread {
     void halt(boolean wait) {
         synchronized (sigLock) {
             halted.set(true);
-            this.interrupt();
 
             if (paused) {
                 sigLock.notifyAll();
@@ -174,7 +173,8 @@ public class QuartzSchedulerThread extends Thread {
                 signalSchedulingChange(0);
             }
         }
-        
+        this.interrupt();
+
         if (wait) {
             boolean interrupted = false;
             try {
@@ -334,6 +334,11 @@ public class QuartzSchedulerThread extends Thread {
                                             sigLock.wait(timeUntilTrigger);
                                     } catch (InterruptedException ignore) {
                                     }
+                                }
+                            }
+                            synchronized (sigLock) {
+                                if (halted.get()) {
+                                    break;
                                 }
                             }
                             if(releaseIfScheduleChangedSignificantly(triggers, triggerTime)) {


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
- Interrupt the scheduler thread when shutdown is occurring, in case it is blocked in a re-try loop on acquiring/releasing triggers.

## Checklist
- [X] tested locally
- [X] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

