### PR TITLE
Add ability in StdScheduleFactory to accept custom JobRunShellFactory.

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/StdSchedulerFactory.java
+++ b/quartz-core/src/main/java/org/quartz/impl/StdSchedulerFactory.java
@@ -213,6 +213,8 @@ public class StdSchedulerFactory implements SchedulerFactory {
     public static final String PROP_DATASOURCE_PREFIX = "org.quartz.dataSource";
 
     public static final String PROP_CONNECTION_PROVIDER_CLASS = "connectionProvider.class";
+    
+    public static final String PROP_JOB_RUN_SHELL_FACTORY_CLASS = "org.quartz.scheduler.jobRunShellFactory.class";
 
     /**
      * @deprecated Replaced with {@link PoolingConnectionProvider#DB_DRIVER}
@@ -1220,26 +1222,39 @@ public class StdSchedulerFactory implements SchedulerFactory {
             log.info("Using default implementation for ThreadExecutor");
             threadExecutor = new DefaultThreadExecutor();
         }
+        
+         //Setup Job Shell Factory.
+         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         
+        JobRunShellFactory jrsf = null; // Create correct run-shell factory...
+        
+        if (userTXLocation != null) {
+            UserTransactionHelper.setUserTxLocation(userTXLocation);
+        }
+
+        if (wrapJobInTx) {
+            jrsf = new JTAJobRunShellFactory();
+        } else {
+            jrsf = new JTAAnnotationAwareJobRunShellFactory();
+        }
+        
+        String jobRunShellFactoryClass = cfg.getStringProperty(PROP_JOB_RUN_SHELL_FACTORY_CLASS);
+        if(jobRunShellFactoryClass != null) {
+            try {
+			  jrsf = (JobRunShellFactory) loadHelper.loadClass(jobRunShellFactoryClass).newInstance();
+			} catch (Exception e) {
+			    initException = new SchedulerException(
+                        "JobRunShellFactory class '" + jobRunShellFactoryClass + "' could not be instantiated.", e);
+                throw initException;
+		    } 
+            log.info("Using custom implementation for JobRunShellFactory: " + jobRunShellFactoryClass);
+        }
 
 
 
         // Fire everything up
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        try {
-                
-    
-            JobRunShellFactory jrsf = null; // Create correct run-shell factory...
-    
-            if (userTXLocation != null) {
-                UserTransactionHelper.setUserTxLocation(userTXLocation);
-            }
-    
-            if (wrapJobInTx) {
-                jrsf = new JTAJobRunShellFactory();
-            } else {
-                jrsf = new JTAAnnotationAwareJobRunShellFactory();
-            }
-    
+        try {              
             if (autoId) {
                 try {
                   schedInstId = DEFAULT_INSTANCE_ID;

--- a/quartz-core/src/test/java/org/quartz/core/MockJobRunShell.java
+++ b/quartz-core/src/test/java/org/quartz/core/MockJobRunShell.java
@@ -1,0 +1,33 @@
+package org.quartz.core;
+
+import org.apache.log4j.MDC;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.spi.TriggerFiredBundle;
+
+/**
+ * JobRunShell whose thread is tagged with a executionId
+ * @author tkashyap
+ *
+ */
+public class MockJobRunShell extends JobRunShell {
+
+	public MockJobRunShell(Scheduler scheduler, TriggerFiredBundle bndle) {
+		super(scheduler, bndle);
+	}
+	
+	/** {@inheritDoc} */
+	  @Override
+	  protected void begin()
+	      throws SchedulerException {
+	    MDC.put("executionId", "xyz");
+	  }
+
+	  /** {@inheritDoc} */
+	  @Override
+	  protected void complete(boolean argSuccessfulExecution)
+	      throws SchedulerException {
+	    MDC.remove("messageid");
+	  }
+
+}

--- a/quartz-core/src/test/java/org/quartz/core/MockJobRunShellFactory.java
+++ b/quartz-core/src/test/java/org/quartz/core/MockJobRunShellFactory.java
@@ -1,0 +1,26 @@
+package org.quartz.core;
+
+import org.quartz.Scheduler;
+import org.quartz.SchedulerConfigException;
+import org.quartz.SchedulerException;
+import org.quartz.spi.TriggerFiredBundle;
+
+/**
+ * @author tkashyap
+ *
+ */
+public class MockJobRunShellFactory implements JobRunShellFactory {
+	
+    private Scheduler scheduler;
+
+    @Override
+    public void initialize(Scheduler scheduler) throws SchedulerConfigException {
+	   this.scheduler = scheduler;		
+	}
+
+	@Override
+	public JobRunShell createJobRunShell(TriggerFiredBundle bundle) throws SchedulerException {
+       return new JobRunShell(scheduler, bundle);
+	}
+
+}

--- a/quartz-core/src/test/java/org/quartz/impl/StdScheduleFactoryCustomJobRunShellFactoryTest.java
+++ b/quartz-core/src/test/java/org/quartz/impl/StdScheduleFactoryCustomJobRunShellFactoryTest.java
@@ -1,0 +1,24 @@
+package org.quartz.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.quartz.Scheduler;
+
+/**
+ * TestCase to verify StdSchedulerFactory initializes correctly a custom JobRunShellFactory.
+ * 
+ * @author tkashyap
+ *
+ */
+public class StdScheduleFactoryCustomJobRunShellFactoryTest {
+	
+	@Test
+	public void loadAndInitializeCustomJobShellFactoryTest() throws Exception {
+	    StdSchedulerFactory factory = new StdSchedulerFactory("org/quartz/properties/quartzCustomJobRunShellFactory.properties");
+        Scheduler scheduler = factory.getScheduler();
+	    scheduler.start();
+	    Assert.assertTrue("Scheduler could not be started with Custom JobRunShellFactory",scheduler.isStarted());
+	    scheduler.shutdown();
+	}
+
+}

--- a/quartz-core/src/test/resources/org/quartz/properties/quartzCustomJobRunShellFactory.properties
+++ b/quartz-core/src/test/resources/org/quartz/properties/quartzCustomJobRunShellFactory.properties
@@ -1,0 +1,6 @@
+# Main Quartz configuration
+org.quartz.scheduler.instanceName = TaggingScheduler
+org.quartz.scheduler.instanceId = NON_CLUSTERED
+org.quartz.threadPool.class = org.quartz.simpl.SimpleThreadPool
+org.quartz.threadPool.threadCount = 5
+org.quartz.scheduler.jobRunShellFactory.class=org.quartz.core.MockJobRunShellFactory


### PR DESCRIPTION
Signed-off-by: Tarun Kashyap <tarun.kashyap@outlook.com>

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This 

- [ ] PR...

## Changes
-Added the ability to the StdSchedulerFactory to pick up a Custom JobRunShellFactory class from the config props input.

## Checklist
- [x] tested locally
- [ ] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #
This is actually an enhancement so that the JobRunShell can be customized. 

