### PR TITLE
Add support to have clusterNodeFailureMarkInterval

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -158,7 +158,8 @@ public abstract class JobStoreSupport implements JobStore, Constants {
     
     private volatile boolean schedulerRunning = false;
     private volatile boolean shutdown = false;
-    
+
+    private long clusterNodeFailureMarkInterval = 15 * 1000L;
     /*
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      * 
@@ -166,6 +167,22 @@ public abstract class JobStoreSupport implements JobStore, Constants {
      * 
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      */
+    /**
+     * <p></p>
+     * The period for which a non responding member in the cluster is marked as a failed node
+     * </p>
+     */
+    public long getClusterNodeFailureMarkInterval() {
+        return clusterNodeFailureMarkInterval;
+    }
+
+    /**
+     * Set the value on which a cluster member is identified as a non-responsive node
+     * @param clusterNodeFailureMarkInterval - The interval mark on which a member is marked as a failure
+     */
+    public void setClusterNodeFailureMarkInterval(long clusterNodeFailureMarkInterval) {
+        this.clusterNodeFailureMarkInterval = clusterNodeFailureMarkInterval;
+    }
 
     /**
      * <p>
@@ -3444,7 +3461,7 @@ public abstract class JobStoreSupport implements JobStore, Constants {
     
     protected long calcFailedIfAfter(SchedulerStateRecord rec) {
         return rec.getCheckinTimestamp() +
-            Math.max(rec.getCheckinInterval(), 
+            Math.max(Math.max(rec.getCheckinInterval(),getClusterNodeFailureMarkInterval()),
                     (System.currentTimeMillis() - lastCheckin)) +
             7500L;
     }


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

## Changes

This PR is opened in relation to https://github.com/quartz-scheduler/quartz/issues/782
A summary of what is done is :
Currently the cluster marks a node as not available if it has not checked in the specified check in interval. However we faced a situation where a checkin did not happen due to a connection hiccup. In that case, currently I did not find any support to specify how long it should wait/ number of times the other nodes should retry to mark it as a non-responsive node and try to recover the job.
In our example this causes a sequential job to be recovered by another server, which result in parallel jbos running and causing data corruptions as we expect these jobs to run sequentially and never concurrently. (Have specified DisallowConcurrentExecution on the jobs as well). Looking at the code for us to give a leniency on marking a server as unavailable, was not possible as it always involve the clusterCheckinInterval. 
So the proposal here is to have another value so that it would make it easy to configure how much a grace time is allowed.
Logic is as if
clusterCheckInInterval = 15 seconds
clusterNodeFailureMarkInterval = 60 seconds

Then if a node fails to check in one iteration the other nodes in the cluster will wait for the completion of 60s plus the leniency time added. this is equivalent for 4 retries and the user has the flexibility on using the values they require.
Also the code makes sure that clusterNodeFailureMarkInterval will ever be a value less that clusterCheckInInterval for obvious reasons, hence if this is not configured and there exists a higher clusterCheckInInterval the usage will not be broken

-

## Checklist
- [X] tested locally
- [x] updated the docs - Added javadocs
- [ ] added appropriate test - No related tests available as this is an update, have left as is
- [X] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

