### PR TITLE
Remove properties and distributionManagement from checkstyle pom.xml

### DIFF
--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -13,12 +13,6 @@
   <name>quartz-checkstyle</name>
   <packaging>jar</packaging>
 
-  <properties>
-    <terracotta-snapshots-url>http://nexus.terracotta.eur.ad.sag/content/repositories/terracotta-snapshots</terracotta-snapshots-url>
-    <terracotta-staging-url>http://nexus.terracotta.eur.ad.sag/content/repositories/terracotta-staging</terracotta-staging-url>
-    <terracotta-releases-url>http://nexus.terracotta.eur.ad.sag/content/repositories/terracotta-releases</terracotta-releases-url>      
-  </properties>
-
   <profiles>
     <profile>
       <id>deploy-sonatype</id>
@@ -37,19 +31,5 @@
       </distributionManagement>
     </profile>    
   </profiles>
-  
-  <distributionManagement>
-    <repository>
-      <id>terracotta-staging</id>
-      <name>Terracotta Staging Repository</name>
-      <url>${terracotta-staging-url}</url>
-    </repository>
-    <snapshotRepository>
-      <id>terracotta-snapshots</id>
-      <uniqueVersion>false</uniqueVersion>
-      <name>Terracotta Snapshots Repository</name>
-      <url>${terracotta-snapshots-url}</url>
-    </snapshotRepository>
-  </distributionManagement>  
 
 </project>


### PR DESCRIPTION
Properties and distributionManagement are defined in parent pom.xml, so there is no reason for keeping them here

Signed-off-by: Martin Konopka <martin.konopka@gmail.com>

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
-

## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

