### PR TITLE
Using row locks instead of cluster wide locks in cluster mode

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/DriverDelegate.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/DriverDelegate.java
@@ -141,7 +141,7 @@ public interface DriverDelegate {
      *         the given count.
      */
     boolean hasMisfiredTriggersInState(Connection conn, String state1, 
-        long ts, int count, List<TriggerKey> resultList) throws SQLException;
+        long ts, int count, List<TriggerKey> resultList, boolean useRowLocks) throws SQLException;
     
     /**
      * <p>
@@ -963,7 +963,7 @@ public interface DriverDelegate {
      *          
      * @return A (never null, possibly empty) list of the identifiers (Key objects) of the next triggers to be fired.
      */
-    public List<TriggerKey> selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan, int maxCount)
+    public List<TriggerKey> selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan, int maxCount, boolean useRowLocks)
         throws SQLException;
 
     /**

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreTX.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreTX.java
@@ -80,8 +80,8 @@ public class JobStoreTX extends JobStoreSupport {
      * @param lockName The name of the lock to aquire, for example 
      * "TRIGGER_ACCESS".  If null, then no lock is aquired, but the
      * lockCallback is still executed in a transaction.
-     * 
-     * @see JobStoreSupport#executeInNonManagedTXLock(String, TransactionCallback)
+     *
+     * @see JobStoreSupport#executeInNonManagedTXLock(String, TransactionCallback, TransactionValidator)
      * @see JobStoreCMT#executeInLock(String, TransactionCallback)
      * @see JobStoreSupport#getNonManagedTXConnection()
      * @see JobStoreSupport#getConnection()

--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
@@ -514,7 +514,8 @@ public interface StdJDBCConstants extends Constants {
         + " AND " + COL_TRIGGER_STATE + " = ? AND " + COL_NEXT_FIRE_TIME + " <= ? " 
         + "AND (" + COL_MISFIRE_INSTRUCTION + " = -1 OR (" +COL_MISFIRE_INSTRUCTION+ " <> -1 AND "+ COL_NEXT_FIRE_TIME + " >= ?)) "
         + "ORDER BY "+ COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
-    
+
+    String FOR_UPDATE_SKIP_LOCKED = "FOR UPDATE SKIP LOCKED";
     
     String INSERT_FIRED_TRIGGER = "INSERT INTO "
             + TABLE_PREFIX_SUBST + TABLE_FIRED_TRIGGERS + " (" + COL_SCHEDULER_NAME + ", " + COL_ENTRY_ID
@@ -661,6 +662,8 @@ public interface StdJDBCConstants extends Constants {
     String DELETE_PAUSED_TRIGGER_GROUPS = "DELETE FROM "
             + TABLE_PREFIX_SUBST + TABLE_PAUSED_TRIGGERS
             + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST;
+
+    String LIMIT = "FETCH FIRST ? ROWS ONLY";
 
     //  CREATE TABLE qrtz_scheduler_state(INSTANCE_NAME VARCHAR2(80) NOT NULL,
     // LAST_CHECKIN_TIME NUMBER(13) NOT NULL, CHECKIN_INTERVAL NUMBER(13) NOT

--- a/quartz-core/src/test/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegateTest.java
+++ b/quartz-core/src/test/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegateTest.java
@@ -150,12 +150,32 @@ public class StdJDBCDelegateTest extends TestCase {
 
         when(preparedStatement.executeQuery()).thenReturn(resultSet);
 
-        when(resultSet.next()).thenReturn(true);
+        when(resultSet.next()).thenReturn(true, true, true, true, true, false);
         when(resultSet.getString(anyString())).thenReturn("test");
 
-        List<TriggerKey> triggerKeys = jdbcDelegate.selectTriggerToAcquire(conn, Long.MAX_VALUE, Long.MIN_VALUE, 10);
+        List<TriggerKey> triggerKeys = jdbcDelegate.selectTriggerToAcquire(conn, Long.MAX_VALUE, Long.MIN_VALUE, 5, false);
 
-        assertThat(triggerKeys, iterableWithSize(10));
+        assertThat(triggerKeys, iterableWithSize(5));
+    }
+
+    public void testSelectTriggerToAcquireHonorsMaxCountUseRowLocks() throws SQLException {
+
+        StdJDBCDelegate jdbcDelegate = new StdJDBCDelegate();
+
+        Connection conn = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+
+        when(conn.prepareStatement(anyString())).thenReturn(preparedStatement);
+
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        when(resultSet.next()).thenReturn(true, true, true, true, true, false);
+        when(resultSet.getString(anyString())).thenReturn("test");
+
+        List<TriggerKey> triggerKeys = jdbcDelegate.selectTriggerToAcquire(conn, Long.MAX_VALUE, Long.MIN_VALUE, 5, true);
+
+        assertThat(triggerKeys, iterableWithSize(5));
     }
 
     static class TestStdJDBCDelegate extends StdJDBCDelegate {


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
-

## Checklist
- [x] tested locally
- [x] updated the docs
- [x] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

