### PR TITLE
Performance Warning

### DIFF
--- a/quartz-core/src/main/java/org/quartz/JobDataMap.java
+++ b/quartz-core/src/main/java/org/quartz/JobDataMap.java
@@ -260,7 +260,7 @@ public class JobDataMap extends StringKeyDirtyFlagMap implements Serializable {
     public int getIntFromString(String key) {
         Object obj = get(key);
 
-        return new Integer((String) obj);
+        return  Integer.parseInt((String) obj);
     }
 
     /**
@@ -381,7 +381,7 @@ public class JobDataMap extends StringKeyDirtyFlagMap implements Serializable {
     public double getDoubleValueFromString(String key) {
         Object obj = get(key);
 
-        return Double.valueOf((String) obj);
+        return Double.parseDouble((String) obj);
     }
 
     /**
@@ -427,7 +427,7 @@ public class JobDataMap extends StringKeyDirtyFlagMap implements Serializable {
     public float getFloatValueFromString(String key) {
         Object obj = get(key);
 
-        return new Float((String) obj);
+        return Float.parseFloat((String) obj);
     }
 
     /**
@@ -473,7 +473,7 @@ public class JobDataMap extends StringKeyDirtyFlagMap implements Serializable {
     public long getLongValueFromString(String key) {
         Object obj = get(key);
 
-        return new Long((String) obj);
+        return Long.parseLong((String) obj);
     }
 
     /**

--- a/quartz-core/src/main/java/org/quartz/xml/XMLSchedulingDataProcessor.java
+++ b/quartz-core/src/main/java/org/quartz/xml/XMLSchedulingDataProcessor.java
@@ -660,7 +660,7 @@ public class XMLSchedulingDataProcessor implements ErrorHandler {
 
             int triggerPriority = Trigger.DEFAULT_PRIORITY;
             if(triggerPriorityString != null)
-                triggerPriority = Integer.valueOf(triggerPriorityString);
+                triggerPriority = Integer.parseInt(triggerPriorityString);
             
             String startTimeString = getTrimmedToNullString(xpath, "q:start-time", triggerNode);
             String startTimeFutureSecsString = getTrimmedToNullString(xpath, "q:start-time-seconds-in-future", triggerNode);
@@ -669,7 +669,7 @@ public class XMLSchedulingDataProcessor implements ErrorHandler {
             //QTZ-273 : use of DatatypeConverter.parseDateTime() instead of SimpleDateFormat
             Date triggerStartTime;
             if(startTimeFutureSecsString != null)
-                triggerStartTime = new Date(System.currentTimeMillis() + (Long.valueOf(startTimeFutureSecsString) * 1000L));
+                triggerStartTime = new Date(System.currentTimeMillis() + (Long.parseLong(startTimeFutureSecsString) * 1000L));
             else 
                 triggerStartTime = (startTimeString == null || startTimeString.length() == 0 ? new Date() : DatatypeConverter.parseDateTime(startTimeString).getTime());
             Date triggerEndTime = endTimeString == null || endTimeString.length() == 0 ? null : DatatypeConverter.parseDateTime(endTimeString).getTime();


### PR DESCRIPTION
…m a String, just to extract the unboxed primitive value. It is more efficient to just call the static parseXXX method.

Signed-off-by: zume0127 <790589151@qq.com>

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
-
Boxing/unboxing to parse a primitive A boxed primitive is created from a String, just to extract the unboxed primitive value. It is more efficient to just call the static parseXXX method.

## Checklist
- [√] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [√] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

