### PR TITLE
Code change to retrieve delegate instance in JobSupport without going through synchronized block

### DIFF
--- a/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -3203,6 +3203,9 @@ public abstract class JobStoreSupport implements JobStore, Constants {
      * </p>
      */
     protected DriverDelegate getDelegate() throws NoSuchDelegateException {
+        if(delegate != null) {
+            return delegate;
+        }
         synchronized(this) {
             if(null == delegate) {
                 try {


### PR DESCRIPTION
Code change to retrieve delegate instance without going through synchronized block. 

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
-

## Checklist
- [ ] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [ ] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

Signed-off-by: Lokesh Alamuri <lokesh.alamuri@gmail.com>
