### PR TITLE
Introduce provided configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,18 @@ allprojects {
                 languageVersion = JavaLanguageVersion.of(11)
             }
         }
+        configurations {
+            provided
+            provided.dependencies.configureEach { dep ->
+                project.dependencies {
+                    constraints {
+                        runtimeOnly("$dep.group:$dep.name:$dep.version")
+                    }
+                }
+            }
+            compileOnly.extendsFrom(provided)
+            testRuntimeOnly.extendsFrom(provided)
+        }
     }
 
     plugins.withType(MavenPublishPlugin) {
@@ -61,7 +73,21 @@ allprojects {
                                 organizationUrl = "http://www.quartz-scheduler.org/"
                             }
                         }
+                        withXml {
+                            def providedXml = configurations.provided.dependencies.collect { dep ->
+                                NodeBuilder.newInstance().dependency {
+                                    createNode('groupId', dep.group)
+                                    createNode('artifactId', dep.name)
+                                    createNode('version', dep.version)
+                                    createNode('scope', 'provided')
+                                }
+                            }
+                            asNode().dependencies.each { deps ->
+                                deps.children().addAll(providedXml)
+                            }
+                        }
                     }
+
                     from components.java
                 }
             }

--- a/quartz/build.gradle
+++ b/quartz/build.gradle
@@ -17,9 +17,9 @@ dependencies {
     compileOnly project(':quartz-stubs')
 
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
-    runtimeOnly "org.slf4j:slf4j-log4j12:$slf4jVersion"
-    implementation "com.mchange:c3p0:$c3p0Version"
-    implementation "com.zaxxer:HikariCP:$hikaricpVersion"
+    provided "org.slf4j:slf4j-log4j12:$slf4jVersion"
+    provided "com.mchange:c3p0:$c3p0Version"
+    provided "com.zaxxer:HikariCP:$hikaricpVersion"
     compileOnly "jboss:jboss-common:$jbossVersion"
     compileOnly "jboss:jboss-minimal:$jbossVersion"
     compileOnly "jboss:jboss-system:$jbossVersion"


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
- Automates the management of provided dependencies and their introduction in to Maven and Gradle metadata.

## Checklist
- [ ] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
