### PR TITLE
Add a sql LIMIT clause for acquire next triggers

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PostgreSQLDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PostgreSQLDelegate.java
@@ -17,13 +17,21 @@
 
 package org.quartz.impl.jdbcjobstore;
 
+import static org.quartz.TriggerKey.triggerKey;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import java.util.LinkedList;
+import java.util.List;
+import org.quartz.TriggerKey;
 import org.quartz.spi.ClassLoadHelper;
 import org.slf4j.Logger;
 
@@ -93,6 +101,42 @@ public class PostgreSQLDelegate extends StdJDBCDelegate {
             return binaryInput;
         }
         return getObjectFromBlob(rs, colName);
+    }
+
+    @Override
+    public List<TriggerKey> selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan, int maxCount)
+        throws SQLException {
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        List<TriggerKey> nextTriggers = new LinkedList<TriggerKey>();
+        try {
+            ps = conn.prepareStatement(rtp(SELECT_NEXT_TRIGGER_TO_ACQUIRE));
+
+            // Set max rows to retrieve
+            if (maxCount < 1)
+                maxCount = 1; // we want at least one trigger back.
+            ps.setMaxRows(maxCount);
+
+            // Try to give jdbc driver a hint to hopefully not pull over more than the few rows we actually need.
+            // Note: in some jdbc drivers, such as MySQL, you must set maxRows before fetchSize, or you get exception!
+            ps.setFetchSize(maxCount);
+
+            ps.setString(1, STATE_WAITING);
+            ps.setBigDecimal(2, new BigDecimal(String.valueOf(noLaterThan)));
+            ps.setBigDecimal(3, new BigDecimal(String.valueOf(noEarlierThan)));
+            rs = ps.executeQuery();
+
+            while (rs.next() && nextTriggers.size() < maxCount) {
+                nextTriggers.add(triggerKey(
+                    rs.getString(COL_TRIGGER_NAME),
+                    rs.getString(COL_TRIGGER_GROUP)));
+            }
+
+            return nextTriggers;
+        } finally {
+            closeResultSet(rs);
+            closeStatement(ps);
+        }
     }
 }
 


### PR DESCRIPTION
In the case where database has a lot of soon-to-be-fired-jobs, the query can be slow as it needs to do extra sort by next_fire_time, priority, the sql LIMIT clause should enable database to be more efficient.

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
-

## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

