### PR TITLE
Fix typo in JobDetail interface

### DIFF
--- a/quartz/src/main/java/org/quartz/JobDetail.java
+++ b/quartz/src/main/java/org/quartz/JobDetail.java
@@ -99,7 +99,7 @@ public interface JobDetail extends Serializable, Cloneable {
      * @see DisallowConcurrentExecution
      * @return whether the associated Job class carries the {@link DisallowConcurrentExecution} annotation.
      */
-    public boolean isConcurrentExectionDisallowed();
+    public boolean isConcurrentExecutionDisallowed();
 
     /**
      * <p>

--- a/quartz/src/main/java/org/quartz/impl/JobDetailImpl.java
+++ b/quartz/src/main/java/org/quartz/impl/JobDetailImpl.java
@@ -386,7 +386,7 @@ public class JobDetailImpl implements Cloneable, java.io.Serializable, JobDetail
     /**
      * @return whether the associated Job class carries the {@link DisallowConcurrentExecution} annotation.
      */
-    public boolean isConcurrentExectionDisallowed() {
+    public boolean isConcurrentExecutionDisallowed() {
         
         return ClassUtils.isAnnotationPresent(jobClass, DisallowConcurrentExecution.class);
     }
@@ -407,7 +407,7 @@ public class JobDetailImpl implements Cloneable, java.io.Serializable, JobDetail
     public String toString() {
         return "JobDetail '" + getFullName() + "':  jobClass: '"
                 + ((getJobClass() == null) ? null : getJobClass().getName())
-                + " concurrentExectionDisallowed: " + isConcurrentExectionDisallowed() 
+                + " concurrentExecutionDisallowed: " + isConcurrentExecutionDisallowed()
                 + " persistJobDataAfterExecution: " + isPersistJobDataAfterExecution() 
                 + " isDurable: " + isDurable() + " requestsRecovers: " + requestsRecovery();
     }

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -1215,7 +1215,7 @@ public abstract class JobStoreSupport implements JobStore, Constants {
                         + ") referenced by the trigger does not exist.");
             }
 
-            if (job.isConcurrentExectionDisallowed() && !recovering) { 
+            if (job.isConcurrentExecutionDisallowed() && !recovering) {
                 state = checkBlockedState(conn, job.getKey(), state);
             }
             
@@ -2872,7 +2872,7 @@ public abstract class JobStoreSupport implements JobStore, Constants {
                         continue;
                     }
                     
-                    if (job.isConcurrentExectionDisallowed()) {
+                    if (job.isConcurrentExecutionDisallowed()) {
                         if (acquiredJobKeysForNoConcurrentExec.contains(jobKey)) {
                             continue; // next trigger
                         } else {
@@ -3071,7 +3071,7 @@ public abstract class JobStoreSupport implements JobStore, Constants {
         String state = STATE_WAITING;
         boolean force = true;
         
-        if (job.isConcurrentExectionDisallowed()) {
+        if (job.isConcurrentExecutionDisallowed()) {
             state = STATE_BLOCKED;
             force = false;
             try {
@@ -3160,7 +3160,7 @@ public abstract class JobStoreSupport implements JobStore, Constants {
                 signalSchedulingChangeOnTxCompletion(0L);
             }
 
-            if (jobDetail.isConcurrentExectionDisallowed()) {
+            if (jobDetail.isConcurrentExecutionDisallowed()) {
                 getDelegate().updateTriggerStatesForJobFromOtherState(conn,
                         jobDetail.getKey(), STATE_WAITING,
                         STATE_BLOCKED);

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PointbaseDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PointbaseDelegate.java
@@ -30,9 +30,7 @@ import java.sql.SQLException;
 
 import org.quartz.Calendar;
 import org.quartz.JobDetail;
-import org.quartz.spi.ClassLoadHelper;
 import org.quartz.spi.OperableTrigger;
-import org.slf4j.Logger;
 
 /**
  * <p>
@@ -79,7 +77,7 @@ public class PointbaseDelegate extends StdJDBCDelegate {
             ps.setString(3, job.getDescription());
             ps.setString(4, job.getJobClass().getName());
             setBoolean(ps, 5, job.isDurable());
-            setBoolean(ps, 6, job.isConcurrentExectionDisallowed());
+            setBoolean(ps, 6, job.isConcurrentExecutionDisallowed());
             setBoolean(ps, 7, job.isPersistJobDataAfterExecution());
             setBoolean(ps, 8, job.requestsRecovery());
             ps.setBinaryStream(9, bais, len);
@@ -122,7 +120,7 @@ public class PointbaseDelegate extends StdJDBCDelegate {
             ps.setString(1, job.getDescription());
             ps.setString(2, job.getJobClass().getName());
             setBoolean(ps, 3, job.isDurable());
-            setBoolean(ps, 4, job.isConcurrentExectionDisallowed());
+            setBoolean(ps, 4, job.isConcurrentExecutionDisallowed());
             setBoolean(ps, 5, job.isPersistJobDataAfterExecution());
             setBoolean(ps, 6, job.requestsRecovery());
             ps.setBinaryStream(7, bais, len);

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
@@ -616,7 +616,7 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
             ps.setString(3, job.getDescription());
             ps.setString(4, job.getJobClass().getName());
             setBoolean(ps, 5, job.isDurable());
-            setBoolean(ps, 6, job.isConcurrentExectionDisallowed());
+            setBoolean(ps, 6, job.isConcurrentExecutionDisallowed());
             setBoolean(ps, 7, job.isPersistJobDataAfterExecution());
             setBoolean(ps, 8, job.requestsRecovery());
             setBytes(ps, 9, baos);
@@ -655,7 +655,7 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
             ps.setString(1, job.getDescription());
             ps.setString(2, job.getJobClass().getName());
             setBoolean(ps, 3, job.isDurable());
-            setBoolean(ps, 4, job.isConcurrentExectionDisallowed());
+            setBoolean(ps, 4, job.isConcurrentExecutionDisallowed());
             setBoolean(ps, 5, job.isPersistJobDataAfterExecution());
             setBoolean(ps, 6, job.requestsRecovery());
             setBytes(ps, 7, baos);
@@ -2655,7 +2655,7 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
             if (job != null) {
                 ps.setString(8, trigger.getJobKey().getName());
                 ps.setString(9, trigger.getJobKey().getGroup());
-                setBoolean(ps, 10, job.isConcurrentExectionDisallowed());
+                setBoolean(ps, 10, job.isConcurrentExecutionDisallowed());
                 setBoolean(ps, 11, job.requestsRecovery());
             } else {
                 ps.setString(8, null);
@@ -2699,7 +2699,7 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
             if (job != null) {
                 ps.setString(5, trigger.getJobKey().getName());
                 ps.setString(6, trigger.getJobKey().getGroup());
-                setBoolean(ps, 7, job.isConcurrentExectionDisallowed());
+                setBoolean(ps, 7, job.isConcurrentExecutionDisallowed());
                 setBoolean(ps, 8, job.requestsRecovery());
             } else {
                 ps.setString(5, null);

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/oracle/OracleDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/oracle/OracleDelegate.java
@@ -32,9 +32,7 @@ import org.quartz.Calendar;
 import org.quartz.JobDetail;
 import org.quartz.impl.jdbcjobstore.StdJDBCDelegate;
 import org.quartz.impl.jdbcjobstore.TriggerPersistenceDelegate;
-import org.quartz.spi.ClassLoadHelper;
 import org.quartz.spi.OperableTrigger;
-import org.slf4j.Logger;
 
 /**
  * <p>
@@ -163,7 +161,7 @@ public class OracleDelegate extends StdJDBCDelegate {
             ps.setString(3, job.getDescription());
             ps.setString(4, job.getJobClass().getName());
             setBoolean(ps, 5, job.isDurable());
-            setBoolean(ps, 6, job.isConcurrentExectionDisallowed());
+            setBoolean(ps, 6, job.isConcurrentExecutionDisallowed());
             setBoolean(ps, 7, job.isPersistJobDataAfterExecution());
             setBoolean(ps, 8, job.requestsRecovery());
 
@@ -231,7 +229,7 @@ public class OracleDelegate extends StdJDBCDelegate {
             ps.setString(1, job.getDescription());
             ps.setString(2, job.getJobClass().getName());
             setBoolean(ps, 3, job.isDurable());
-            setBoolean(ps, 4, job.isConcurrentExectionDisallowed());
+            setBoolean(ps, 4, job.isConcurrentExecutionDisallowed());
             setBoolean(ps, 5, job.isPersistJobDataAfterExecution());
             setBoolean(ps, 6, job.requestsRecovery());
             ps.setString(7, job.getKey().getName());

--- a/quartz/src/main/java/org/quartz/simpl/RAMJobStore.java
+++ b/quartz/src/main/java/org/quartz/simpl/RAMJobStore.java
@@ -24,7 +24,6 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +44,6 @@ import org.quartz.TriggerKey;
 import org.quartz.Trigger.CompletedExecutionInstruction;
 import org.quartz.Trigger.TriggerState;
 import org.quartz.Trigger.TriggerTimeComparator;
-import org.quartz.impl.JobDetailImpl;
 import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.impl.matchers.StringMatcher;
 import org.quartz.spi.ClassLoadHelper;
@@ -56,8 +54,6 @@ import org.quartz.spi.TriggerFiredBundle;
 import org.quartz.spi.TriggerFiredResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.quartz.impl.matchers.EverythingMatcher.allTriggers;
 
 /**
  * <p>
@@ -1487,7 +1483,7 @@ public class RAMJobStore implements JobStore {
                 // put it back into the timeTriggers set and continue to search for next trigger.
                 JobKey jobKey = tw.trigger.getJobKey();
                 JobDetail job = jobsByKey.get(tw.trigger.getJobKey()).jobDetail;
-                if (job.isConcurrentExectionDisallowed()) {
+                if (job.isConcurrentExecutionDisallowed()) {
                     if (acquiredJobKeysForNoConcurrentExec.contains(jobKey)) {
                         excludedTriggers.add(tw);
                         continue; // go to next trigger in store.
@@ -1576,7 +1572,7 @@ public class RAMJobStore implements JobStore {
 
                 JobDetail job = bndle.getJobDetail();
 
-                if (job.isConcurrentExectionDisallowed()) {
+                if (job.isConcurrentExecutionDisallowed()) {
                     ArrayList<TriggerWrapper> trigs = getTriggerWrappersForJob(job.getKey());
                     for (TriggerWrapper ttw : trigs) {
                         if (ttw.state == TriggerWrapper.STATE_WAITING) {
@@ -1633,7 +1629,7 @@ public class RAMJobStore implements JobStore {
                     jd = jd.getJobBuilder().setJobData(newData).build();
                     jw.jobDetail = jd;
                 }
-                if (jd.isConcurrentExectionDisallowed()) {
+                if (jd.isConcurrentExecutionDisallowed()) {
                     blockedJobs.remove(jd.getKey());
                     ArrayList<TriggerWrapper> trigs = getTriggerWrappersForJob(jd.getKey());
                     for(TriggerWrapper ttw : trigs) {

--- a/quartz/src/test/java/org/quartz/JobBuilderTest.java
+++ b/quartz/src/test/java/org/quartz/JobBuilderTest.java
@@ -64,7 +64,7 @@ public class JobBuilderTest extends TestCase {
         assertTrue("Unexpected job description: " + job.getDescription(), job.getDescription() == null);
         assertTrue("Expected isDurable == true ", job.isDurable());
         assertFalse("Expected requestsRecovery == false ", job.requestsRecovery());
-        assertFalse("Expected isConcurrentExectionDisallowed == false ", job.isConcurrentExectionDisallowed());
+        assertFalse("Expected isConcurrentExecutionDisallowed == false ", job.isConcurrentExecutionDisallowed());
         assertFalse("Expected isPersistJobDataAfterExecution == false ", job.isPersistJobDataAfterExecution());
         assertTrue("Unexpected job class: " + job.getJobClass(), job.getJobClass().equals(TestJob.class));
         
@@ -79,7 +79,7 @@ public class JobBuilderTest extends TestCase {
         assertTrue("Unexpected job description: " + job.getDescription(), job.getDescription().equals("my description"));
         assertTrue("Expected isDurable == true ", job.isDurable());
         assertTrue("Expected requestsRecovery == true ", job.requestsRecovery());
-        assertTrue("Expected isConcurrentExectionDisallowed == true ", job.isConcurrentExectionDisallowed());
+        assertTrue("Expected isConcurrentExecutionDisallowed == true ", job.isConcurrentExecutionDisallowed());
         assertTrue("Expected isPersistJobDataAfterExecution == true ", job.isPersistJobDataAfterExecution());
         
         job = newJob()
@@ -91,7 +91,7 @@ public class JobBuilderTest extends TestCase {
         assertTrue("Unexpected job group: " + job.getKey().getName(), job.getKey().getGroup().equals("g1"));
         assertFalse("Expected isDurable == false ", job.isDurable());
         assertFalse("Expected requestsRecovery == false ", job.requestsRecovery());
-        assertTrue("Expected isConcurrentExectionDisallowed == true ", job.isConcurrentExectionDisallowed());
+        assertTrue("Expected isConcurrentExecutionDisallowed == true ", job.isConcurrentExecutionDisallowed());
         assertTrue("Expected isPersistJobDataAfterExecution == true ", job.isPersistJobDataAfterExecution());
      
     }

--- a/quartz/src/test/java/org/quartz/JobDetailTest.java
+++ b/quartz/src/test/java/org/quartz/JobDetailTest.java
@@ -79,34 +79,34 @@ public class JobDetailTest extends TestCase {
 
         jobDetail.setJobClass(SomePersistentJob.class);
         assertTrue("Expecting SomePersistentJob to be persistent", jobDetail.isPersistJobDataAfterExecution());
-        assertFalse("Expecting SomePersistentJob to not disallow concurrent execution", jobDetail.isConcurrentExectionDisallowed());
+        assertFalse("Expecting SomePersistentJob to not disallow concurrent execution", jobDetail.isConcurrentExecutionDisallowed());
 
         jobDetail.setJobClass(SomeNonConcurrentJob.class);
         assertFalse("Expecting SomeNonConcurrentJob to not be persistent", jobDetail.isPersistJobDataAfterExecution());
-        assertTrue("Expecting SomeNonConcurrentJob to disallow concurrent execution", jobDetail.isConcurrentExectionDisallowed());
+        assertTrue("Expecting SomeNonConcurrentJob to disallow concurrent execution", jobDetail.isConcurrentExecutionDisallowed());
 
         jobDetail.setJobClass(SomeNonConcurrentPersistentJob.class);
         assertTrue("Expecting SomeNonConcurrentPersistentJob to be persistent", jobDetail.isPersistJobDataAfterExecution());
-        assertTrue("Expecting SomeNonConcurrentPersistentJob to disallow concurrent execution", jobDetail.isConcurrentExectionDisallowed());
+        assertTrue("Expecting SomeNonConcurrentPersistentJob to disallow concurrent execution", jobDetail.isConcurrentExecutionDisallowed());
 
         jobDetail.setJobClass(SomeStatefulJob.class);
         assertTrue("Expecting SomeStatefulJob to be persistent", jobDetail.isPersistJobDataAfterExecution());
-        assertTrue("Expecting SomeStatefulJob to disallow concurrent execution", jobDetail.isConcurrentExectionDisallowed());
+        assertTrue("Expecting SomeStatefulJob to disallow concurrent execution", jobDetail.isConcurrentExecutionDisallowed());
 
         jobDetail.setJobClass(SomeExtendedPersistentJob.class);
         assertTrue("Expecting SomeExtendedPersistentJob to be persistent", jobDetail.isPersistJobDataAfterExecution());
-        assertFalse("Expecting SomeExtendedPersistentJob to not disallow concurrent execution", jobDetail.isConcurrentExectionDisallowed());
+        assertFalse("Expecting SomeExtendedPersistentJob to not disallow concurrent execution", jobDetail.isConcurrentExecutionDisallowed());
 
         jobDetail.setJobClass(SomeExtendedNonConcurrentJob.class);
         assertFalse("Expecting SomeExtendedNonConcurrentJob to not be persistent", jobDetail.isPersistJobDataAfterExecution());
-        assertTrue("Expecting SomeExtendedNonConcurrentJob to disallow concurrent execution", jobDetail.isConcurrentExectionDisallowed());
+        assertTrue("Expecting SomeExtendedNonConcurrentJob to disallow concurrent execution", jobDetail.isConcurrentExecutionDisallowed());
 
         jobDetail.setJobClass(SomeExtendedNonConcurrentPersistentJob.class);
         assertTrue("Expecting SomeExtendedNonConcurrentPersistentJob to be persistent", jobDetail.isPersistJobDataAfterExecution());
-        assertTrue("Expecting SomeExtendedNonConcurrentPersistentJob to disallow concurrent execution", jobDetail.isConcurrentExectionDisallowed());
+        assertTrue("Expecting SomeExtendedNonConcurrentPersistentJob to disallow concurrent execution", jobDetail.isConcurrentExecutionDisallowed());
 
         jobDetail.setJobClass(SomeExtendedStatefulJob.class);
         assertTrue("Expecting SomeExtendedStatefulJob to be persistent", jobDetail.isPersistJobDataAfterExecution());
-        assertTrue("Expecting SomeExtendedStatefulJob to disallow concurrent execution", jobDetail.isConcurrentExectionDisallowed());
+        assertTrue("Expecting SomeExtendedStatefulJob to disallow concurrent execution", jobDetail.isConcurrentExecutionDisallowed());
     }
 }


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
- Name of the method `isConcurrentExectionDisallowed` to `isConcurrentExecutionDisallowed` in `JobDetail`

## Checklist
- [x] tested locally
- [x] updated the docs
- [x] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

## Fixes
- #953 
- A typo in the name of method `isConcurrentExectionDisallowed` under `JobDetail` interface
