### PR TITLE
Fix format of PR template to adhere to markdown

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,9 @@ In submitting this contribution, I agree to the current Software AG contributor 
 https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
 
 This PR...
+
 ## Changes
--
+- 
 
 ## Checklist
 - [ ] tested locally
@@ -12,5 +13,5 @@ This PR...
 - [ ] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
   (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
 
-Fixes #
-
+## Fixes
+- 


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...

## Changes
- Formatting of GitHub PR template

## Checklist
- [x] tested locally
- [x] updated the docs
- [x] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

## Fixes
- Formatting of GitHub PR template
