### PR TITLE
Add quartz.properties file for example5

### DIFF
--- a/examples/src/main/java/org/quartz/examples/example5/MisfireExample.java
+++ b/examples/src/main/java/org/quartz/examples/example5/MisfireExample.java
@@ -58,7 +58,7 @@ public class MisfireExample {
     log.info("------- Initializing -------------------");
 
     // First we must get a reference to a scheduler
-    SchedulerFactory sf = new StdSchedulerFactory();
+    SchedulerFactory sf = new StdSchedulerFactory("org/quartz/examples/example5/quartz_misfire.properties");
     Scheduler sched = sf.getScheduler();
 
     log.info("------- Initialization Complete -----------");

--- a/examples/src/main/resources/org/quartz/examples/example5/quartz_misfire.properties
+++ b/examples/src/main/resources/org/quartz/examples/example5/quartz_misfire.properties
@@ -1,0 +1,9 @@
+org.quartz.scheduler.instanceName: MisfireExampleScheduler
+
+org.quartz.threadPool.threadCount: 2
+org.quartz.threadPool.class: org.quartz.simpl.SimpleThreadPool
+
+# Set misfire threshold to 1 second
+org.quartz.jobStore.misfireThreshold: 1000
+org.quartz.jobStore.class: org.quartz.simpl.RAMJobStore
+


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR adds quartz.properties file for example5. The current version of the example5 doesn't showcase misfires. This PR fixes that.
## Changes
- Add and use quartz.properties file for example5

## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #
example5 output
