### PR TITLE
When storing job with replace check update count returned

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -1112,9 +1112,12 @@ public abstract class JobStoreSupport implements JobStore, Constants {
                 if (!replaceExisting) { 
                     throw new ObjectAlreadyExistsException(newJob); 
                 }
-                getDelegate().updateJobDetail(conn, newJob);
-            } else {
-                getDelegate().insertJobDetail(conn, newJob);
+                if (getDelegate().updateJobDetail(conn, newJob) > 0) {
+                    return;
+                }
+            }
+            if (getDelegate().insertJobDetail(conn, newJob) < 1) {
+                throw new JobPersistenceException("Couldn't store job. Insert failed.");
             }
         } catch (IOException e) {
             throw new JobPersistenceException("Couldn't store job: "


### PR DESCRIPTION
This is to detect non-durable job suddenly disappearing when concurrently completing. On MariaDB/MySQL the fall-through code path select-update-insert can be taken due to consistent nonblocking read and multi-version concurrency control.

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

## Changes
The code change checks the update count returned when storing a job.

## Checklist
- [x] tested locally
- [x] updated the docs (not applicable, bug fix only)
- [x] added appropriate test (not applicable, storeJob method covered in tests already)
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 

Fixes #1085