### PR TITLE
Java 21 virtual thread support 

### DIFF
--- a/quartz/build.gradle
+++ b/quartz/build.gradle
@@ -88,3 +88,14 @@ processResources {
         expand([version: project.version, fullname: project.fullname, name: project.name])
     }
 }
+
+ext {
+    JDK_PATH = System.getProperty("jdk")
+}
+
+tasks.withType(Test).configureEach {
+    if ( JDK_PATH != null  ) {
+        println("External Java home '${JDK_PATH}' spefified for tests!")
+        executable = new File(JDK_PATH, 'bin/java')
+    }
+}

--- a/quartz/src/main/java/org/quartz/simpl/SimpleVirtualThreadPool.java
+++ b/quartz/src/main/java/org/quartz/simpl/SimpleVirtualThreadPool.java
@@ -1,0 +1,124 @@
+/* 
+ * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+ * use this file except in compliance with the License. You may obtain a copy 
+ * of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+ * License for the specific language governing permissions and limitations 
+ * under the License.
+ * 
+ */
+
+package org.quartz.simpl;
+
+import org.quartz.SchedulerConfigException;
+import org.quartz.spi.ThreadPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * <p>
+ * This is class is a simple implementation of a java 21 virtual thread pool, based on the
+ * <code>{@link ThreadPool}</code> interface.
+ * </p>
+ * 
+ * <p>
+ * <CODE>Runnable</CODE> objects are sent to the pool with the <code>{@link #runInThread(Runnable)}</code>
+ * method, which blocks until a <code>Thread</code> becomes available.
+ * </p>
+ * 
+ * <p>
+ * The pool has unlimited number of virtual <code>Thread</code>
+ * </p>
+ * 
+ * @author Nabarun Mondal
+ *
+ */
+public class SimpleVirtualThreadPool implements ThreadPool {
+
+    private static final Logger log = LoggerFactory.getLogger( SimpleVirtualThreadPool.class );
+
+    private static <T> T safeCall(Callable<T> callable , String message ){
+        try{
+            return callable.call();
+        }catch (Throwable ex){
+            log.warn( message + ex);
+            return null;
+        }
+    }
+
+    private static Method getVirtualExecutorCreator(){
+        return safeCall(() -> Executors.class.getMethod("newVirtualThreadPerTaskExecutor"),
+                "Runtime does not have support for java 21 virtual threads : ");
+    }
+
+    private static final Method SERVICE_CREATOR = getVirtualExecutorCreator();
+
+    public static boolean isVirtualThreadSupported(){
+        return SERVICE_CREATOR != null;
+    }
+
+    private static ExecutorService getVirtualExecutor(){
+        return safeCall( () ->(ExecutorService)SERVICE_CREATOR.invoke(null),
+                "Failed to create Virtual Executor Service! Possibly Runtime has no support for Virtual Threads : ");
+    }
+    private  ExecutorService executorService = null ;
+
+    public SimpleVirtualThreadPool(){
+        if ( !isVirtualThreadSupported() ) throw new UnsupportedOperationException( "Virtual Threads are not supported!" );
+    }
+
+    @Override
+    public boolean runInThread(Runnable runnable) {
+        if ( executorService != null ){
+            executorService.submit(runnable);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public int blockForAvailableThreads() {
+        return Integer.MAX_VALUE ; // does not block, there is potentially no limit
+    }
+
+    @Override
+    public void initialize() throws SchedulerConfigException {
+        executorService = getVirtualExecutor();
+        if ( executorService == null ) throw new SchedulerConfigException("Virtual Threads are not supported!");
+    }
+
+    @Override
+    public void shutdown(boolean waitForJobsToComplete) {
+        if ( waitForJobsToComplete ){
+            executorService.shutdown();
+        } else {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Override
+    public int getPoolSize() {
+        return Integer.MAX_VALUE ; // because it is unlimited
+    }
+
+    @Override
+    public void setInstanceId(String schedInstId) {}
+    @Override
+    public void setInstanceName(String schedName) {}
+}

--- a/quartz/src/test/java/org/quartz/VirtualThreadedSchedulerTest.java
+++ b/quartz/src/test/java/org/quartz/VirtualThreadedSchedulerTest.java
@@ -1,0 +1,45 @@
+/*
+ * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.quartz;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.quartz.impl.DirectSchedulerFactory;
+import org.quartz.impl.SchedulerRepository;
+import org.quartz.impl.jdbcjobstore.JdbcQuartzTestUtilities;
+import org.quartz.impl.jdbcjobstore.JobStoreTX;
+import org.quartz.simpl.RAMJobStore;
+import org.quartz.simpl.SimpleThreadPool;
+import org.quartz.simpl.SimpleVirtualThreadPool;
+import org.quartz.spi.JobStore;
+
+import java.sql.SQLException;
+
+public class VirtualThreadedSchedulerTest extends AbstractSchedulerTest {
+
+    @BeforeClass
+    public static void runOnlyWhenVThreadAvailable(){
+        Assume.assumeTrue("Virtual Threading is not available!",SimpleVirtualThreadPool.isVirtualThreadSupported() );
+    }
+
+    @Override
+    protected Scheduler createScheduler(String name, int threadPoolSize) throws SchedulerException {
+        final String schedulerName = name + "VScheduler" ;
+        DirectSchedulerFactory.getInstance().createScheduler(schedulerName, "AUTO", new SimpleVirtualThreadPool(), new RAMJobStore());
+        return SchedulerRepository.getInstance().lookup(schedulerName);
+    }
+}

--- a/quartz/src/test/java/org/quartz/VirtualThreadedSchedulerTest.java
+++ b/quartz/src/test/java/org/quartz/VirtualThreadedSchedulerTest.java
@@ -15,19 +15,25 @@
  */
 package org.quartz;
 
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
+import org.junit.Test;
 import org.quartz.impl.DirectSchedulerFactory;
 import org.quartz.impl.SchedulerRepository;
-import org.quartz.impl.jdbcjobstore.JdbcQuartzTestUtilities;
-import org.quartz.impl.jdbcjobstore.JobStoreTX;
 import org.quartz.simpl.RAMJobStore;
-import org.quartz.simpl.SimpleThreadPool;
 import org.quartz.simpl.SimpleVirtualThreadPool;
-import org.quartz.spi.JobStore;
 
-import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertFalse;
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.TriggerBuilder.newTrigger;
 
 public class VirtualThreadedSchedulerTest extends AbstractSchedulerTest {
 
@@ -41,5 +47,75 @@ public class VirtualThreadedSchedulerTest extends AbstractSchedulerTest {
         final String schedulerName = name + "VScheduler" ;
         DirectSchedulerFactory.getInstance().createScheduler(schedulerName, "AUTO", new SimpleVirtualThreadPool(), new RAMJobStore());
         return SchedulerRepository.getInstance().lookup(schedulerName);
+    }
+
+    public static class TimeAdjustedJob implements Job {
+
+        Throwable err = null ;
+
+        @Override
+        public void execute(JobExecutionContext context) {
+
+            try {
+                SchedulerContext schedulerContext = context.getScheduler().getContext();
+                schedulerContext.put("JOB_THREAD", Thread.currentThread());
+                schedulerContext.put("JOB_INSTANCE", this);
+                long wait =  (long) schedulerContext.get("WAIT_TIME");
+                Thread.sleep(wait); // job keeps on waiting
+            } catch (Throwable e) {
+                err = e;
+            }
+        }
+    }
+    @Override
+    @Test
+    public void testShutdownWithoutWaitIsUnclean() throws Exception {
+        Scheduler scheduler = createScheduler("testShutdownWithoutWaitIsUnclean", 8);
+
+        scheduler.getContext().put("WAIT_TIME", Long.MAX_VALUE);
+        scheduler.start();
+        scheduler.addJob(newJob().ofType(TimeAdjustedJob.class).withIdentity("job").storeDurably().build(), false);
+        scheduler.scheduleJob(newTrigger().forJob("job").startNow().build());
+        while (scheduler.getCurrentlyExecutingJobs().isEmpty()) {
+            Thread.sleep(50);
+        }
+        scheduler.shutdown(false); // try doing it here..
+        //At this point, we still would have the job running.. like forever...
+        Thread taskThread = (Thread)scheduler.getContext().get("JOB_THREAD");
+        Assert.assertTrue(taskThread.isAlive()); // this is what we test
+        taskThread.interrupt(); // now we close it out
+        Thread.sleep(50);
+        TimeAdjustedJob job = (TimeAdjustedJob)scheduler.getContext().get("JOB_INSTANCE");
+        Assert.assertTrue( job.err instanceof InterruptedException ); // this implies we have succeeded
+    }
+
+    @Override
+    @Test
+    public void testShutdownWithWaitIsClean() throws Exception {
+        final AtomicBoolean shutdown = new AtomicBoolean(false);
+        final Scheduler scheduler = createScheduler("testShutdownWithWaitIsClean", 8);
+        scheduler.getContext().put("WAIT_TIME", 1500L);
+        scheduler.start();
+        scheduler.addJob(newJob().ofType(TimeAdjustedJob.class).withIdentity("job").storeDurably().build(), false);
+        scheduler.scheduleJob(newTrigger().forJob("job").startNow().build());
+        while (scheduler.getCurrentlyExecutingJobs().isEmpty()) {
+            Thread.sleep(50);
+        }
+
+        Thread t = new Thread(() -> {
+            try {
+                scheduler.shutdown(true);
+                shutdown.set(true);
+                //At this point, we still would not have the job running..
+                Thread taskThread = (Thread)scheduler.getContext().get("JOB_THREAD");
+                assertFalse(taskThread.isAlive());
+
+            } catch (SchedulerException ex) {
+                throw new RuntimeException(ex);
+            }
+        });
+        t.start();
+        t.join();
+        Assert.assertTrue( shutdown.get() );
     }
 }


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...

## How to Run

```
./gradlew -Djdk="<jdk 21 directory>"  test :quartz:test 

```


## Changes

Adds a `SimpleVirtualThreadPool` to do a virtual thread support.

## Checklist
- [x]  tested locally
- [x]   updated the docs
- [x]  added appropriate test
- [x]  signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

## Known Issues

In java 21 - the following tests fail:

```
> Task :quartz:test

org.quartz.impl.jdbcjobstore.StdJDBCDelegateTest > testSelectSimpleTriggerWithDeleteBeforeSelectExtendedProps FAILED
    java.lang.ExceptionInInitializerError at StdJDBCDelegateTest.java:119
        Caused by: java.lang.reflect.InaccessibleObjectException at StdJDBCDelegateTest.java:119

org.quartz.impl.jdbcjobstore.StdJDBCDelegateTest > testSelectSimpleTriggerWithExceptionWithExtendedProps FAILED
    java.lang.NoClassDefFoundError at StdJDBCDelegateTest.java:90
        Caused by: java.lang.ExceptionInInitializerError at StdJDBCDelegateTest.java:119

org.quartz.impl.jdbcjobstore.StdJDBCDelegateTest > testSelectBlobTriggerWithNoBlobContent FAILED
    java.lang.NoClassDefFoundError at StdJDBCDelegateTest.java:73
        Caused by: java.lang.ExceptionInInitializerError at StdJDBCDelegateTest.java:119

org.quartz.impl.jdbcjobstore.StdJDBCDelegateTest > testSelectTriggerToAcquireHonorsMaxCount FAILED
    java.lang.NoClassDefFoundError at StdJDBCDelegateTest.java:145
        Caused by: java.lang.ExceptionInInitializerError at StdJDBCDelegateTest.java:119

org.quartz.impl.jdbcjobstore.UpdateLockRowSemaphoreTest > testSingleFailureFollowedBySuccessUsingUpdate FAILED
    java.lang.ExceptionInInitializerError at UpdateLockRowSemaphoreTest.java:35
        Caused by: java.lang.reflect.InaccessibleObjectException at UpdateLockRowSemaphoreTest.java:35

org.quartz.impl.jdbcjobstore.UpdateLockRowSemaphoreTest > testDoubleFailureFollowedBySuccessUsingUpdate FAILED
    java.lang.NoClassDefFoundError at Unsafe.java:-2
        Caused by: java.lang.ExceptionInInitializerError at UpdateLockRowSemaphoreTest.java:35

org.quartz.impl.jdbcjobstore.UpdateLockRowSemaphoreTest > testFallThroughToInsert FAILED
    java.lang.NoClassDefFoundError at Unsafe.java:-2
        Caused by: java.lang.ExceptionInInitializerError at UpdateLockRowSemaphoreTest.java:35

org.quartz.impl.jdbcjobstore.UpdateLockRowSemaphoreTest > testSingleSuccessUsingUpdate FAILED
    java.lang.NoClassDefFoundError at Unsafe.java:-2
        Caused by: java.lang.ExceptionInInitializerError at UpdateLockRowSemaphoreTest.java:35

319 tests completed, 8 failed, 1 skipped

> Task :quartz:test FAILED

FAILURE: Build failed with an exception.

```




