### PR TITLE
remove unmatched paren (matches error log more closely)

### DIFF
--- a/quartz/src/main/java/org/quartz/core/JobRunShell.java
+++ b/quartz/src/main/java/org/quartz/core/JobRunShell.java
@@ -212,7 +212,7 @@ public class JobRunShell extends SchedulerListenerSupport implements Runnable {
                             " threw an unhandled Exception: ", e);
                     SchedulerException se = new SchedulerException(
                             "Job threw an unhandled exception.", e);
-                    qs.notifySchedulerListenersError("Job ("
+                    qs.notifySchedulerListenersError("Job "
                             + jec.getJobDetail().getKey()
                             + " threw an exception.", se);
                     jobExEx = new JobExecutionException(se, false);


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
- Removes an unmatched paren that was annoying my coworker @hyperschwartz
- Opted to remove the paren rather than add a matching one so it matches the log mesage above on lines 211-212

## Checklist
- [x] tested locally
- [x] updated the docs
- [x] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

