### PR TITLE
Add Automatic-Module-Name attribute to jar manifest…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,8 @@ allprojects {
                         "Implementation-Vendor-Id": project.group,
                         "Implementation-Version": project.version,
                         "Built-By": System.getProperty("user.name"),
-                        "Built-JDK": System.getProperty("java.version")
+                        "Built-JDK": System.getProperty("java.version"),
+                        "Automatic-Module-Name": 'org.quartz'
                 )
             }
         }


### PR DESCRIPTION
…+ for better Java 9+ JPMS compatibility

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Adds Automatic-Module-Name attribute to jar manifest

## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #

