### PR TITLE
Fixed typo in JavaDoc

### DIFF
--- a/quartz/src/main/java/org/quartz/spi/JobFactory.java
+++ b/quartz/src/main/java/org/quartz/spi/JobFactory.java
@@ -29,7 +29,7 @@ import org.quartz.SchedulerException;
  * <p>
  * This interface may be of use to those wishing to have their application
  * produce <code>Job</code> instances via some special mechanism, such as to
- * give the opertunity for dependency injection.
+ * give the opportunity for dependency injection.
  * </p>
  * 
  * @see org.quartz.Scheduler#setJobFactory(JobFactory)


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

## Changes
- fixed typo in Javadoc of JobFactory.java to correctly spell "opportunity"

## Checklist
- [x] tested locally
- [x] updated the docs
- [ ] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 


