### PR TITLE
fix: use ClassLoaderObjectInputStream to resolve class loading issue …

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/CUBRIDDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/CUBRIDDelegate.java
@@ -59,12 +59,7 @@ public class CUBRIDDelegate extends StdJDBCDelegate {
         if (bytes != null && bytes.length != 0) {
             binaryInput = new ByteArrayInputStream(bytes);
 
-            ObjectInputStream in = new ObjectInputStream(binaryInput);
-            try {
-                obj = in.readObject();
-            } finally {
-                in.close();
-            }
+            obj = getObject(binaryInput);
         }
 
         return obj;

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/CacheDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/CacheDelegate.java
@@ -79,12 +79,7 @@ public class CacheDelegate extends StdJDBCDelegate {
                     } else if (binaryInput instanceof ByteArrayInputStream && ((ByteArrayInputStream) binaryInput).available() == 0 ) {
                         return null;
                     } else {
-                        ObjectInputStream in = new ObjectInputStream(binaryInput);
-                        try {
-                            return in.readObject();
-                        } finally {
-                            in.close();
-                        }
+                        return getObject(binaryInput);
                     }
                 }
             } finally {

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/HSQLDBDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/HSQLDBDelegate.java
@@ -66,17 +66,8 @@ public class HSQLDBDelegate extends StdJDBCDelegate {
         if(binaryInput == null || binaryInput.available() == 0) {
             return null;
         }
-        
-        Object obj = null;
-        
-        ObjectInputStream in = new ObjectInputStream(binaryInput);
-        try {
-            obj = in.readObject();
-        } finally {
-            in.close();
-        }
 
-        return obj;
+        return getObject(binaryInput);
     }
 
     @Override           

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/MSSQLDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/MSSQLDelegate.java
@@ -65,16 +65,7 @@ public class MSSQLDelegate extends StdJDBCDelegate {
             return null;
         }
 
-        Object obj = null;
-
-        ObjectInputStream in = new ObjectInputStream(binaryInput);
-        try {
-            obj = in.readObject();
-        } finally {
-            in.close();
-        }
-
-        return obj;
+        return getObject(binaryInput);
     }
 
     @Override           

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PointbaseDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PointbaseDelegate.java
@@ -411,12 +411,7 @@ public class PointbaseDelegate extends StdJDBCDelegate {
         InputStream binaryInput = new ByteArrayInputStream(binaryData);
 
         if (null != binaryInput && binaryInput.available() != 0) {
-            ObjectInputStream in = new ObjectInputStream(binaryInput);
-            try {
-                obj = in.readObject();
-            } finally {
-                in.close();
-            }
+            obj = getObject(binaryInput);
         }
 
         return obj;

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PostgreSQLDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PostgreSQLDelegate.java
@@ -67,13 +67,8 @@ public class PostgreSQLDelegate extends StdJDBCDelegate {
         
         if(bytes != null && bytes.length != 0) {
             binaryInput = new ByteArrayInputStream(bytes);
-        
-            ObjectInputStream in = new ObjectInputStream(binaryInput);
-            try {
-                obj = in.readObject();
-            } finally {
-                in.close();
-            }
+
+            obj = getObject(binaryInput);
 
         }
         

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
@@ -21,13 +21,8 @@ import static org.quartz.JobKey.jobKey;
 import static org.quartz.TriggerBuilder.newTrigger;
 import static org.quartz.TriggerKey.triggerKey;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.NotSerializableException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.*;
+import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.sql.Blob;
 import java.sql.Connection;
@@ -3198,15 +3193,22 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
                     && ((ByteArrayInputStream) binaryInput).available() == 0 ) {
                     //do nothing
                 } else {
-                    ObjectInputStream in = new ObjectInputStream(binaryInput);
-                    try {
-                        obj = in.readObject();
-                    } finally {
-                        in.close();
-                    }
+                    obj = getObject(binaryInput);
                 }
             }
 
+        }
+        return obj;
+    }
+
+    protected Object getObject(InputStream binaryInput) throws IOException, ClassNotFoundException {
+        Object obj;
+        ClassLoader currentThreadClassLoader = Thread.currentThread().getContextClassLoader();
+        if (null == currentThreadClassLoader) {
+            currentThreadClassLoader = this.getClass().getClassLoader();
+        }
+        try (ObjectInputStream in = new ClassLoaderObjectInputStream(currentThreadClassLoader, binaryInput)) {
+            obj = in.readObject();
         }
         return obj;
     }
@@ -3336,6 +3338,38 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
     protected void setBytes(PreparedStatement ps, int index, ByteArrayOutputStream baos) throws SQLException {
         ps.setBytes(index, (baos == null) ? new byte[0] : baos.toByteArray());
     }
+
+    protected static class ClassLoaderObjectInputStream extends ObjectInputStream {
+        private final ClassLoader classLoader;
+
+        public ClassLoaderObjectInputStream(ClassLoader classLoader, InputStream inputStream) throws IOException, StreamCorruptedException {
+            super(inputStream);
+            this.classLoader = classLoader;
+        }
+
+        protected Class<?> resolveClass(ObjectStreamClass objectStreamClass) throws IOException, ClassNotFoundException {
+            try {
+                return Class.forName(objectStreamClass.getName(), false, this.classLoader);
+            } catch (ClassNotFoundException var3) {
+                return super.resolveClass(objectStreamClass);
+            }
+        }
+
+        protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
+            Class<?>[] interfaceClasses = new Class[interfaces.length];
+
+            for(int i = 0; i < interfaces.length; ++i) {
+                interfaceClasses[i] = Class.forName(interfaces[i], false, this.classLoader);
+            }
+
+            try {
+                return Proxy.getProxyClass(this.classLoader, interfaceClasses);
+            } catch (IllegalArgumentException var4) {
+                return super.resolveProxyClass(interfaces);
+            }
+        }
+    }
+
 }
 
 // EOF

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/SybaseDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/SybaseDelegate.java
@@ -69,16 +69,7 @@ public class SybaseDelegate extends StdJDBCDelegate {
             return null;
         }
 
-        Object obj = null;
-
-        ObjectInputStream in = new ObjectInputStream(binaryInput);
-        try {
-            obj = in.readObject();
-        } finally {
-            in.close();
-        }
-
-        return obj;
+        return getObject(binaryInput);
     }
 
     @Override           

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/WebLogicDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/WebLogicDelegate.java
@@ -74,12 +74,7 @@ public class WebLogicDelegate extends StdJDBCDelegate {
         }
 
         if (null != binaryInput) {
-            ObjectInputStream in = new ObjectInputStream(binaryInput);
-            try {
-                obj = in.readObject();
-            } finally {
-                in.close();
-            }
+            obj = getObject(binaryInput);
         }
 
         return obj;

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/oracle/OracleDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/oracle/OracleDelegate.java
@@ -136,12 +136,7 @@ public class OracleDelegate extends StdJDBCDelegate {
         Object obj = null;
         InputStream binaryInput = rs.getBinaryStream(colName);
         if (binaryInput != null) {
-            ObjectInputStream in = new ObjectInputStream(binaryInput);
-            try {
-                obj = in.readObject();
-            } finally {
-                in.close();
-            }
+            obj = getObject(binaryInput);
         }
 
         return obj;


### PR DESCRIPTION
…in getObjectFromBlob

Quartz currently uses ObjectInputStream in getObjectFromBlob, which can lead to class loading issues when the class being deserialized is not loaded by the same class loader as Quartz. This commit replaces ObjectInputStream with ClassLoaderObjectInputStream to ensure that the correct class loader is used during deserialization.

- Replaced ObjectInputStream with ClassLoaderObjectInputStream in getObjectFromBlob method.
- Added a new ClassLoaderObjectInputStream class to handle custom class loading.

This change resolves the issue where deserialized objects are not recognized due to class loader mismatches, improving compatibility in environments with multiple class loaders.

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes

## Checklist


Fixes #

