### PR TITLE
Fixed broken hyper links in tutorilas section

### DIFF
--- a/docs/tutorials/index.adoc
+++ b/docs/tutorials/index.adoc
@@ -7,30 +7,30 @@ Before starting the tutorial, you may first want to review the <<../quick-start-
 
 == Choose a Lesson:
 
-link:tutorial-lesson-01.html[Lesson 1: Using Quartz]
+link:tutorial-lesson-01.md[Lesson 1: Using Quartz]
 
-link:tutorial-lesson-02.html[Lesson 2: The Quartz API, and Introduction to Jobs And Triggers]
+link:tutorial-lesson-02.md[Lesson 2: The Quartz API, and Introduction to Jobs And Triggers]
 
-link:tutorial-lesson-03.html[Lesson 3: More About Jobs &amp; JobDetails]
+link:tutorial-lesson-03.md[Lesson 3: More About Jobs &amp; JobDetails]
 
-link:tutorial-lesson-04.html[Lesson 4: More About Triggers]
+link:tutorial-lesson-04.md[Lesson 4: More About Triggers]
 
-link:tutorial-lesson-05.html[Lesson 5: SimpleTriggers]
+link:tutorial-lesson-05.md[Lesson 5: SimpleTriggers]
 
-link:tutorial-lesson-06.html[Lesson 6: CronTriggers]
+link:tutorial-lesson-06.md[Lesson 6: CronTriggers]
 
-link:tutorial-lesson-07.html[Lesson 7: TriggerListeners &amp; JobListeners]
+link:tutorial-lesson-07.md[Lesson 7: TriggerListeners &amp; JobListeners]
 
-link:tutorial-lesson-08.html[Lesson 8: SchedulerListeners]
+link:tutorial-lesson-08.md[Lesson 8: SchedulerListeners]
 
-link:tutorial-lesson-09.html[Lesson 9: JobStores]
+link:tutorial-lesson-09.md[Lesson 9: JobStores]
 
-link:tutorial-lesson-10.html[Lesson 10: Configuration, Resource Usage and SchedulerFactory]
+link:tutorial-lesson-10.md[Lesson 10: Configuration, Resource Usage and SchedulerFactory]
 
-link:tutorial-lesson-11.html[Lesson 11: Advanced (Enterprise) Features]
+link:tutorial-lesson-11.md[Lesson 11: Advanced (Enterprise) Features]
 
-link:tutorial-lesson-12.html[Lesson 12: Miscellaneous Features]
+link:tutorial-lesson-12.md[Lesson 12: Miscellaneous Features]
 
 == Choose a Special Topic:
 
-link:crontrigger.html[CronTrigger Tutorial]
+link:crontrigger.md[CronTrigger Tutorial]

--- a/docs/tutorials/tutorial-lesson-01.md
+++ b/docs/tutorials/tutorial-lesson-01.md
@@ -5,7 +5,7 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-02.html" title="Go to Lesson 2">Lesson 2&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-02.md" title="Go to Lesson 2">Lesson 2&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 1: Using Quartz

--- a/docs/tutorials/tutorial-lesson-02.md
+++ b/docs/tutorials/tutorial-lesson-02.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-01.html" title="Go to Lesson 2">&lsaquo;&nbsp;Lesson 1</a> |
-          <a href="tutorial-lesson-03.html" title="Go to Lesson 2">Lesson 3&nbsp;&rsaquo;</a> |
+          <a href="tutorial-lesson-01.md" title="Go to Lesson 2">&lsaquo;&nbsp;Lesson 1</a> |
+          <a href="tutorial-lesson-03.md" title="Go to Lesson 2">Lesson 3&nbsp;&rsaquo;</a> |
 </div>
 
 ## Lesson 2: The Quartz API, Jobs And Triggers
@@ -27,7 +27,7 @@ A **Scheduler**'s life-cycle is bounded by it's creation, via a **SchedulerFacto
 a call to its *shutdown()* method.  Once created the Scheduler interface can be used add, remove, and list
 Jobs and Triggers, and perform other scheduling-related operations (such as pausing a trigger).  However, the
 Scheduler will not actually act on any triggers (execute jobs) until it has been started with the *start()*
-method, as shown in <a href="tutorial-lesson-01.html" title="Go to Lesson 1">Lesson 1</a>.       
+method, as shown in <a href="tutorial-lesson-01.md" title="Go to Lesson 1">Lesson 1</a>.       
 
 Quartz provides "builder" classes that define a Domain Specific Language (or DSL, also sometimes referred to as
 a "fluent interface"). In the previous lesson you saw an example of it, which we present a portion of here again:
@@ -135,5 +135,5 @@ compound of the name and group.
 
 
 You now have a general idea about what Jobs and Triggers are, you can learn more about them in <a
-    href="tutorial-lesson-03.html" title="Tutorial Lesson 3">Lesson 3: More About Jobs &amp; JobDetails</a> and <a
-    href="tutorial-lesson-04.html" title="Tutorial Lesson 4">Lesson 4: More About Triggers</a>.
+    href="tutorial-lesson-03.md" title="Tutorial Lesson 3">Lesson 3: More About Jobs &amp; JobDetails</a> and <a
+    href="tutorial-lesson-04.md" title="Tutorial Lesson 4">Lesson 4: More About Triggers</a>.

--- a/docs/tutorials/tutorial-lesson-03.md
+++ b/docs/tutorials/tutorial-lesson-03.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-02.html" title="Go to Lesson 2">&lsaquo;&nbsp;Lesson 2</a> |
-          <a href="tutorial-lesson-04.html" title="Go to Lesson 4">Lesson 4&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-02.md" title="Go to Lesson 2">&lsaquo;&nbsp;Lesson 2</a> |
+          <a href="tutorial-lesson-04.md" title="Go to Lesson 4">Lesson 4&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 3: More About Jobs and Job Details

--- a/docs/tutorials/tutorial-lesson-04.md
+++ b/docs/tutorials/tutorial-lesson-04.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-03.html" title="Go to Lesson 3">&lsaquo;&nbsp;Lesson 3</a> |
-          <a href="tutorial-lesson-05.html" title="Go to Lesson 5">Lesson 5&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-03.md" title="Go to Lesson 3">&lsaquo;&nbsp;Lesson 3</a> |
+          <a href="tutorial-lesson-05.md" title="Go to Lesson 5">Lesson 5&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 4: More About Triggers
@@ -15,8 +15,8 @@ Like jobs, triggers are quite easy to work with, but do contain a variety of cus
 need to be aware of and understand before you can make full use of Quartz. Also, as noted earlier, there are different
 types of triggers that you can select from to meet different scheduling needs.
 
-You will learn about the two most common types of triggers in <a href="tutorial-lesson-05.html"
-    title="Tutorial Lesson 5">Lesson 5: Simple Triggers</a> and <a href="tutorial-lesson-06.html" title="Tutorial Lesson 6">Lesson 6: Cron Triggers</a>.
+You will learn about the two most common types of triggers in <a href="tutorial-lesson-05.md"
+    title="Tutorial Lesson 5">Lesson 5: Simple Triggers</a> and <a href="tutorial-lesson-06.md" title="Tutorial Lesson 6">Lesson 6: Cron Triggers</a>.
 
 ### [Common Trigger Attributes](#TutorialLesson4-CommonAttrs)
 

--- a/docs/tutorials/tutorial-lesson-05.md
+++ b/docs/tutorials/tutorial-lesson-05.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-04.html" title="Go to Lesson 4">&lsaquo;&nbsp;Lesson 4</a> |
-          <a href="tutorial-lesson-06.html" title="Go to Lesson 6">Lesson 6&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-04.md" title="Go to Lesson 4">&lsaquo;&nbsp;Lesson 4</a> |
+          <a href="tutorial-lesson-06.md" title="Go to Lesson 6">Lesson 6&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 5: SimpleTrigger

--- a/docs/tutorials/tutorial-lesson-06.md
+++ b/docs/tutorials/tutorial-lesson-06.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-05.html" title="Go to Lesson 5">&lsaquo;&nbsp;Lesson 5</a> |
-          <a href="tutorial-lesson-07.html" title="Go to Lesson 7">Lesson 7&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-05.md" title="Go to Lesson 5">&lsaquo;&nbsp;Lesson 5</a> |
+          <a href="tutorial-lesson-07.md" title="Go to Lesson 7">Lesson 7&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 6: CronTrigger

--- a/docs/tutorials/tutorial-lesson-07.md
+++ b/docs/tutorials/tutorial-lesson-07.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-06.html" title="Go to Lesson 6">&lsaquo;&nbsp;Lesson 6</a> |
-          <a href="tutorial-lesson-08.html" title="Go to Lesson 8">Lesson 8&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-06.md" title="Go to Lesson 6">&lsaquo;&nbsp;Lesson 6</a> |
+          <a href="tutorial-lesson-08.md" title="Go to Lesson 8">Lesson 8&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 7: TriggerListeners and JobListeners

--- a/docs/tutorials/tutorial-lesson-08.md
+++ b/docs/tutorials/tutorial-lesson-08.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-07.html" title="Go to Lesson 7">&lsaquo;&nbsp;Lesson 7</a> |
-          <a href="tutorial-lesson-09.html" title="Go to Lesson 9">Lesson 9&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-07.md" title="Go to Lesson 7">&lsaquo;&nbsp;Lesson 7</a> |
+          <a href="tutorial-lesson-09.md" title="Go to Lesson 9">Lesson 9&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 8: SchedulerListeners

--- a/docs/tutorials/tutorial-lesson-09.md
+++ b/docs/tutorials/tutorial-lesson-09.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-08.html" title="Go to Lesson 8">&lsaquo;&nbsp;Lesson 8</a> |
-          <a href="tutorial-lesson-10.html" title="Go to Lesson 10">Lesson 10&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-08.md" title="Go to Lesson 8">&lsaquo;&nbsp;Lesson 8</a> |
+          <a href="tutorial-lesson-10.md" title="Go to Lesson 10">Lesson 10&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 9: Job Stores

--- a/docs/tutorials/tutorial-lesson-10.md
+++ b/docs/tutorials/tutorial-lesson-10.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-09.html" title="Go to Lesson 9">&lsaquo;&nbsp;Lesson 9</a> |
-          <a href="tutorial-lesson-11.html" title="Go to Lesson 11">Lesson 11&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-09.md" title="Go to Lesson 9">&lsaquo;&nbsp;Lesson 9</a> |
+          <a href="tutorial-lesson-11.md" title="Go to Lesson 11">Lesson 11&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 10: Configuration, Resource Usage and SchedulerFactory

--- a/docs/tutorials/tutorial-lesson-11.md
+++ b/docs/tutorials/tutorial-lesson-11.md
@@ -5,8 +5,8 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-10.html" title="Go to Lesson 10">&lsaquo;&nbsp;Lesson 10</a> |
-          <a href="tutorial-lesson-12.html" title="Go to Lesson 12">Lesson 12&nbsp;&rsaquo;</a>
+          <a href="tutorial-lesson-10.md" title="Go to Lesson 10">&lsaquo;&nbsp;Lesson 10</a> |
+          <a href="tutorial-lesson-12.md" title="Go to Lesson 12">Lesson 12&nbsp;&rsaquo;</a>
 </div>
 
 ## Lesson 11: Advanced (Enterprise) Features
@@ -41,7 +41,7 @@ same node that just was just active for non-busy (e.g. one or two triggers) sche
 
 #### Clustering With TerracottaJobStore
 Simply configure the scheduler to use TerracottaJobStore (covered in
-<a href="tutorial-lesson-09.html" title="Tutorial Lesson 9">Lesson 9: JobStores</a>), and your scheduler will be all
+<a href="tutorial-lesson-09.md" title="Tutorial Lesson 9">Lesson 9: JobStores</a>), and your scheduler will be all
 set for clustering.
 
 You may also want to consider implications of how you setup your Terracotta server, particularly configuration
@@ -56,7 +56,7 @@ More information about this JobStore and Terracotta can be found at
 
 ### [JTA Transactions](#TutorialLesson11-JTATransactions)
 
-As explained in <a href="tutorial-lesson-09.html" title="Tutorial Lesson 9">Lesson 9: JobStores</a>, JobStoreCMT
+As explained in <a href="tutorial-lesson-09.md" title="Tutorial Lesson 9">Lesson 9: JobStores</a>, JobStoreCMT
 allows Quartz scheduling operations to be performed within larger JTA transactions.
 
 Jobs can also execute within a JTA transaction (UserTransaction) by setting the

--- a/docs/tutorials/tutorial-lesson-12.md
+++ b/docs/tutorials/tutorial-lesson-12.md
@@ -5,7 +5,7 @@ active_sub_menu_id: site_mnu_docs_tutorials
 ---
 <div class="secNavPanel">
           <a href="./" title="Go to Tutorial Table of Contents">Table of Contents</a> |
-          <a href="tutorial-lesson-11.html" title="Go to Lesson 2">&lsaquo;&nbsp;Lesson 11</a>
+          <a href="tutorial-lesson-11.md" title="Go to Lesson 2">&lsaquo;&nbsp;Lesson 11</a>
 </div>
 
 ## Lesson 12: Miscellaneous Features of Quartz


### PR DESCRIPTION
In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR updates the hyperlinks in the tutorials section to ensure that files with the `.md` extension are correctly linked, resolving issues where some files were incorrectly linked with `.html`, leading to "Page not found" errors.

## Changes
- Updated all tutorial hyperlinks from `.html` to `.md` to fix broken links.

## Checklist
- [x] tested locally
- [x] updated the docs
- [ ] added appropriate test
- [x] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits.
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )


![image](https://github.com/user-attachments/assets/58e98e25-b517-40fc-9539-273cc70a54c8)

