### PR TITLE
remove unmatched paren (matches error log more closely)

### DIFF
--- a/quartz/src/main/java/org/quartz/core/JobRunShell.java
+++ b/quartz/src/main/java/org/quartz/core/JobRunShell.java
@@ -212,7 +212,7 @@ public class JobRunShell extends SchedulerListenerSupport implements Runnable {
                             " threw an unhandled Exception: ", e);
                     SchedulerException se = new SchedulerException(
                             "Job threw an unhandled exception.", e);
-                    qs.notifySchedulerListenersError("Job ("
+                    qs.notifySchedulerListenersError("Job "
                             + jec.getJobDetail().getKey()
                             + " threw an exception.", se);
                     jobExEx = new JobExecutionException(se, false);


### PR DESCRIPTION
This PR...

Fixes issue #

## Changes
- Removes an unmatched paren that was annoying my coworker @hyperschwartz
- Opted to remove the paren rather than add a matching one so it matches the log message above on lines 211-212

re-opening of #1112 

-----------------
## Checklist
- [x] tested locally
- [x] updated the docs
- [x] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

