### PR TITLE
Fix loading of long properties

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/SimplePropertiesTriggerPersistenceDelegateSupport.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/SimplePropertiesTriggerPersistenceDelegateSupport.java
@@ -160,8 +160,8 @@ public abstract class SimplePropertiesTriggerPersistenceDelegateSupport implemen
                 properties.setString3(rs.getString(COL_STR_PROP_3));
                 properties.setInt1(rs.getInt(COL_INT_PROP_1));
                 properties.setInt2(rs.getInt(COL_INT_PROP_2));
-                properties.setLong1(rs.getInt(COL_LONG_PROP_1));
-                properties.setLong2(rs.getInt(COL_LONG_PROP_2));
+                properties.setLong1(rs.getLong(COL_LONG_PROP_1));
+                properties.setLong2(rs.getLong(COL_LONG_PROP_2));
                 properties.setDecimal1(rs.getBigDecimal(COL_DEC_PROP_1));
                 properties.setDecimal2(rs.getBigDecimal(COL_DEC_PROP_2));
                 properties.setBoolean1(rs.getBoolean(COL_BOOL_PROP_1));

--- a/quartz/src/test/java/org/quartz/integrations/tests/QuartzDatabaseSimplePropertiesTest.java
+++ b/quartz/src/test/java/org/quartz/integrations/tests/QuartzDatabaseSimplePropertiesTest.java
@@ -1,0 +1,139 @@
+/* 
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+ * use this file except in compliance with the License. You may obtain a copy 
+ * of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+ * License for the specific language governing permissions and limitations 
+ * under the License.
+ */
+package org.quartz.integrations.tests;
+
+import java.math.BigDecimal;
+import java.util.Properties;
+
+import org.junit.Test;
+
+import org.quartz.JobDetail;
+import org.quartz.ScheduleBuilder;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleTrigger;
+import org.quartz.TriggerKey;
+import org.quartz.impl.jdbcjobstore.SimplePropertiesTriggerPersistenceDelegateSupport;
+import org.quartz.impl.jdbcjobstore.SimplePropertiesTriggerProperties;
+import org.quartz.impl.triggers.SimpleTriggerImpl;
+import org.quartz.spi.MutableTrigger;
+import org.quartz.spi.OperableTrigger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.TriggerBuilder.newTrigger;
+
+public class QuartzDatabaseSimplePropertiesTest extends QuartzDatabaseTestSupport {
+
+	@Override
+	protected Properties createSchedulerProperties() {
+		Properties defaultSchedulerProperties = super.createSchedulerProperties();
+		defaultSchedulerProperties.put(
+				"org.quartz.jobStore.driverDelegateInitString",
+				"triggerPersistenceDelegateClasses=" + TestSimplePropertiesTriggerPersistenceDelegate.class.getName()
+		);
+		return defaultSchedulerProperties;
+	}
+
+	@Test
+	public void insertAndLoadProperties() throws SchedulerException {
+		TriggerKey triggerKey = new TriggerKey("test");
+		TestTriggerImpl trigger = (TestTriggerImpl) newTrigger()
+				.withIdentity(triggerKey)
+				.withSchedule(new TestTriggerScheduleBuilder())
+				.build();
+
+		SimplePropertiesTriggerProperties insertedProperties = new SimplePropertiesTriggerProperties();
+		insertedProperties.setString1("");
+		insertedProperties.setString2(null);
+		insertedProperties.setString3("test-string");
+		insertedProperties.setInt1(Integer.MIN_VALUE);
+		insertedProperties.setInt2(Integer.MAX_VALUE);
+		insertedProperties.setLong1(Long.MIN_VALUE);
+		insertedProperties.setLong2(Long.MAX_VALUE);
+		insertedProperties.setDecimal1(new BigDecimal("0.0000"));
+		insertedProperties.setDecimal2(new BigDecimal("-10.0000"));
+		insertedProperties.setBoolean1(true);
+		insertedProperties.setBoolean2(false);
+		trigger.setAdditionalProperties(insertedProperties);
+
+		JobDetail job = newJob(HelloJob.class).withIdentity("test").build();
+
+		scheduler.scheduleJob(job, trigger);
+		TestTriggerImpl loadedTrigger = ((TestTriggerImpl) scheduler.getTrigger(triggerKey));
+
+		SimplePropertiesTriggerProperties loadedProperties = loadedTrigger.getAdditionalProperties();
+		assertThat(loadedProperties, samePropertyValuesAs(insertedProperties));
+	}
+
+	public static class TestTriggerImpl extends SimpleTriggerImpl {
+		private SimplePropertiesTriggerProperties additionalProperties;
+
+		@Override
+		public boolean hasAdditionalProperties() {
+			return true;
+		}
+
+		public SimplePropertiesTriggerProperties getAdditionalProperties() {
+			return additionalProperties;
+		}
+
+		public void setAdditionalProperties(SimplePropertiesTriggerProperties additionalProperties) {
+			this.additionalProperties = additionalProperties;
+		}
+
+		@Override
+		public ScheduleBuilder<SimpleTrigger> getScheduleBuilder() {
+			return new TestTriggerScheduleBuilder();
+		}
+	}
+
+	public static class TestTriggerScheduleBuilder extends ScheduleBuilder<SimpleTrigger> {
+
+		@Override
+		protected MutableTrigger build() {
+			return new TestTriggerImpl();
+		}
+	}
+
+	public static class TestSimplePropertiesTriggerPersistenceDelegate extends
+			SimplePropertiesTriggerPersistenceDelegateSupport {
+
+		@Override
+		public boolean canHandleTriggerType(OperableTrigger trigger) {
+			return trigger instanceof TestTriggerImpl;
+		}
+
+		@Override
+		public String getHandledTriggerTypeDiscriminator() {
+			return "TEST";
+		}
+
+		@Override
+		protected SimplePropertiesTriggerProperties getTriggerProperties(OperableTrigger trigger) {
+			return ((TestTriggerImpl) trigger).getAdditionalProperties();
+		}
+
+		@Override
+		protected TriggerPropertyBundle getTriggerPropertyBundle(SimplePropertiesTriggerProperties properties) {
+			return new TriggerPropertyBundle(
+					new TestTriggerScheduleBuilder(),
+					new String[] {"additionalProperties"},
+					new Object[] {properties}
+			);
+		}
+	}
+}


### PR DESCRIPTION
Resubmitting changes from #1141 after the change of ownership of the project (as requested by @jhouserizer and @melloware).

Fixes issue #1140 

-----------------

## Changes
- loading `long`s as `long`s instead of `int`s

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [x] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

