### PR TITLE
Improve some of the javadoc language around repeat count

### DIFF
--- a/quartz/src/main/java/org/quartz/SimpleScheduleBuilder.java
+++ b/quartz/src/main/java/org/quartz/SimpleScheduleBuilder.java
@@ -325,10 +325,10 @@ public class SimpleScheduleBuilder extends ScheduleBuilder<SimpleTrigger> {
     }
     
     /**
-     * Specify a the number of time the trigger will repeat - total number of 
+     * Specify the number of times the trigger will repeat - the total number of
      * firings will be this number + 1. 
      * 
-     * @param triggerRepeatCount the number of seconds at which the trigger should repeat.
+     * @param triggerRepeatCount the number of times the trigger should repeat after the initial firing.
      * @return the updated SimpleScheduleBuilder
      * @see SimpleTrigger#getRepeatCount()
      * @see #repeatForever()

--- a/quartz/src/main/java/org/quartz/SimpleTrigger.java
+++ b/quartz/src/main/java/org/quartz/SimpleTrigger.java
@@ -138,11 +138,12 @@ public interface SimpleTrigger extends Trigger {
     public static final int REPEAT_INDEFINITELY = -1;
 
     /**
-     * <p>
      * Get the number of times the <code>SimpleTrigger</code> should
-     * repeat, after which it will be automatically deleted.
-     * </p>
-     * 
+     * repeat, after the initial firing, after which it will be automatically deleted.
+     *
+     * The total number of firings will be this number + 1.
+     *
+     * @return the number of times the trigger should repeat after the initial firing.
      * @see #REPEAT_INDEFINITELY
      */
     public int getRepeatCount();


### PR DESCRIPTION
This PR...

Improves some of the language around repeat count of simple triggers - hopefully making it more clear for all english readers.

## Changes
-

-----------------
## Checklist
- [X] tested locally
- [X] updated the docs
- [ ] added appropriate test
- [X] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

