### PR TITLE
Quartz 2.4.x update dependencies to jakarta  version compatible with the package name javax.*

### DIFF
--- a/quartz-jobs/build.gradle
+++ b/quartz-jobs/build.gradle
@@ -9,12 +9,12 @@ dependencies {
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
     runtimeOnly "org.slf4j:slf4j-log4j12:$slf4jVersion"
 
-    compileOnly 'javax.jms:javax.jms-api:2.0.1'
-    compileOnly 'javax.mail:mail:1.4.7'
+    compileOnly 'jakarta.jms:jakarta.jms-api:2.0.3'
+    compileOnly 'jakarta.mail:jakarta.mail-api:1.6.7'
     compileOnly 'org.apache.openejb:javaee-api:6.0-5'
     compileOnly 'org.glassfish.corba:rmic:4.2.5'
 
-    testImplementation 'javax.transaction:javax.transaction-api:1.3'
+    testImplementation 'jakarta.transaction:jakarta.transaction-api:1.3.3'
     testImplementation 'commons-io:commons-io:2.17.0'
     testImplementation "junit:junit:$junitVersion"
     testImplementation 'org.hamcrest:hamcrest-library:1.2'


### PR DESCRIPTION
<!--
If this is your first time contributing to the project (or it's been a while), please consider reviewing https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
-->


This PR  replace the javax dependencies by its Jakarta  compatible version (package name still remains under javax.*)

Fixes issue #

## Changes
-Update dependencies

-----------------
## Checklist
- [x ] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x ] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

