### PR TITLE
Fixed typo in JavaDoc of JobFactory.java

### DIFF
--- a/quartz/src/main/java/org/quartz/spi/JobFactory.java
+++ b/quartz/src/main/java/org/quartz/spi/JobFactory.java
@@ -30,7 +30,7 @@ import org.quartz.SchedulerException;
  * <p>
  * This interface may be of use to those wishing to have their application
  * produce <code>Job</code> instances via some special mechanism, such as to
- * give the opertunity for dependency injection.
+ * give the opportunity for dependency injection.
  * </p>
  * 
  * @see org.quartz.Scheduler#setJobFactory(JobFactory)


### PR DESCRIPTION

## Changes
- fixed typo in Javadoc of JobFactory.java to correctly spell "opportunity"

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

