### PR TITLE
Fix #1122 add direct reference to smart misfire policies

### DIFF
--- a/quartz/src/main/java/org/quartz/Trigger.java
+++ b/quartz/src/main/java/org/quartz/Trigger.java
@@ -102,6 +102,11 @@ public interface Trigger extends Serializable, Cloneable, Comparable<Trigger> {
      * the documentation for the <code>updateAfterMisfire()</code> method
      * on the particular <code>Trigger</code> implementation you are using.
      * </p>
+     *
+     * @see org.quartz.impl.triggers.SimpleTriggerImpl#updateAfterMisfire(Calendar)
+     * @see org.quartz.impl.triggers.CronTriggerImpl#updateAfterMisfire(Calendar)
+     * @see org.quartz.impl.triggers.DailyTimeIntervalTriggerImpl#updateAfterMisfire(Calendar)
+     * @see org.quartz.impl.triggers.CalendarIntervalTriggerImpl#updateAfterMisfire(Calendar)
      */
     int MISFIRE_INSTRUCTION_SMART_POLICY = 0;
     


### PR DESCRIPTION

This PR...

Fixes issue #1122 add direct reference to smart misfire policies on various core trigger types

## Changes
-

-----------------
## Checklist
- [X] tested locally
- [X] updated the docs
- [ ] added appropriate test
- [X] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

