### PR TITLE
Fix error logging in job interruption during shutdown

### DIFF
--- a/quartz/src/main/java/org/quartz/core/QuartzScheduler.java
+++ b/quartz/src/main/java/org/quartz/core/QuartzScheduler.java
@@ -694,7 +694,7 @@ public class QuartzScheduler implements RemotableQuartzScheduler {
                         ((InterruptableJob)job.getJobInstance()).interrupt();
                     } catch (Throwable e) {
                         // do nothing, this was just a courtesy effort
-                        getLog().warn("Encountered error when interrupting job {} during shutdown: {}", job.getJobDetail().getKey(), e);
+                        getLog().warn("Encountered error when interrupting job {} during shutdown: {}", job.getJobDetail().getKey(), e.getMessage(), e);
                     }
             }
         }


### PR DESCRIPTION
Number of placeholders does not match number of arguments in logging call

This PR...

Fixes issue #

## Changes
- Updated the log message to include the exception's message and stack trace when an error occurs during job interruption in the QuartzScheduler. This will provide more detailed information for diagnosing shutdown issues.

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

