### PR TITLE
Fix: Language-Dependent Test #1213

### DIFF
--- a/quartz/src/test/java/org/quartz/xml/XMLSchedulingDataProcessorTest.java
+++ b/quartz/src/test/java/org/quartz/xml/XMLSchedulingDataProcessorTest.java
@@ -376,7 +376,7 @@ public class XMLSchedulingDataProcessorTest extends TestCase {
 
 			fail("Expected parser configuration to block DOCTYPE. The following was injected into the job description field: " + description);
 		} catch (SAXParseException e) {
-			assertTrue(e.getMessage().contains("DOCTYPE is disallowed"));
+			assertTrue(e.getMessage().toLowerCase().contains("doctype"));
 		} finally {
 			if (scheduler != null)
 				scheduler.shutdown();


### PR DESCRIPTION
<!--
If this is your first time contributing to the project (or it's been a while), please consider reviewing https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
-->
The tests fail when the system language is not set to English

This PR...

Fixes issue #1213

## Changes
- Relax the test's assertion

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

