### PR TITLE
when storing job with replace check update count returned

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -1112,9 +1112,12 @@ public abstract class JobStoreSupport implements JobStore, Constants {
                 if (!replaceExisting) { 
                     throw new ObjectAlreadyExistsException(newJob); 
                 }
-                getDelegate().updateJobDetail(conn, newJob);
-            } else {
-                getDelegate().insertJobDetail(conn, newJob);
+                if (getDelegate().updateJobDetail(conn, newJob) > 0) {
+                    return;
+                }
+            }
+            if (getDelegate().insertJobDetail(conn, newJob) < 1) {
+                throw new JobPersistenceException("Couldn't store job. Insert failed.");
             }
         } catch (IOException e) {
             throw new JobPersistenceException("Couldn't store job: "


### PR DESCRIPTION
This is to detect non-durable job suddenly disappearing when concurrently completing. On MariaDB/MySQL the fall-through code path select-update-insert can be taken due to consistent nonblocking read and multi-version concurrency control.

This PR...

Fixes issue #1085 

## Changes

The code change checks the update count returned when storing a job.

-----------------
## Checklist
- [x] tested locally
- [x] updated the docs (not applicable, bug fix only)
- [x] added appropriate test (not applicable, storeJob method covered in tests already)
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners

-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

