### PR TITLE
Fix array index overflow in CircularLossyQueue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ jbossVersion = 4.0.2
 commonjVersion = 1.0
 
 junitVersion = 4.13.2
-
+junitPlatformVersion = 5.11.3
 #derbyVersion = 10.15.2.0
 derbyVersion = 10.8.2.2
 

--- a/quartz/build.gradle
+++ b/quartz/build.gradle
@@ -32,7 +32,10 @@ dependencies {
     testImplementation 'jakarta.transaction:jakarta.transaction-api:2.0.1'
     compileOnly 'jakarta.servlet:jakarta.servlet-api:6.1.0'
 
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junitPlatformVersion"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitPlatformVersion"
     testImplementation "junit:junit:$junitVersion"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junitPlatformVersion"
     testImplementation 'asm:asm:3.3.1'
     testImplementation 'org.mockito:mockito-core:1.9.5'
     testImplementation 'org.hamcrest:hamcrest-library:3.0'
@@ -45,6 +48,8 @@ dependencies {
 test {
     maxParallelForks 1
     forkEvery 1
+    useJUnitPlatform {
+    }
 }
 
 java {

--- a/quartz/src/test/java/org/quartz/utils/CircularLossyQueueTest.java
+++ b/quartz/src/test/java/org/quartz/utils/CircularLossyQueueTest.java
@@ -1,0 +1,97 @@
+package org.quartz.utils;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CircularLossyQueueTest {
+
+	@Test
+	void testNewCircularLossyQueueShouldBeEmpty() {
+		Long[] array = new Long[5];
+		CircularLossyQueue<Long> queue = new CircularLossyQueue<>(5);
+		queue.toArray(array);
+
+		assertAll("emptyQueue",
+				() -> assertTrue(queue.isEmpty()),
+				() -> assertNull(queue.peek()),
+				() -> assertArrayEquals(new Long[] { null, null, null, null, null }, array)
+		);
+	}
+
+	@Test
+	void testPushIntoNotFullQueue() {
+		Long[] array = new Long[5];
+		CircularLossyQueue<Long> queue = new CircularLossyQueue<>(5);
+
+		int depthBefore = queue.depth();
+
+		queue.push(1L);
+		queue.toArray(array);
+
+		assertAll("pushIntoNotFullQueue",
+				() -> assertFalse(queue.isEmpty()),
+				() -> assertEquals(depthBefore + 1, queue.depth()),
+				() -> assertEquals(1L, queue.peek()),
+				() -> assertArrayEquals(new Long[] { 1L, null, null, null, null }, array)
+		);
+	}
+
+	@Test
+	void testPushIntoFullQueue() {
+		Long[] array = new Long[5];
+		CircularLossyQueue<Long> queue = new CircularLossyQueue<>(5);
+
+		for (long value = 1L; value < 6L; value++) {
+			queue.push(value);
+		}
+
+		int depthBefore = queue.depth();
+
+		queue.push(6L);
+		queue.toArray(array);
+
+		assertAll("pushIntoFullQueue",
+				() -> assertFalse(queue.isEmpty()),
+				() -> assertEquals(depthBefore, queue.depth()),
+				() -> assertEquals(6L, queue.peek()),
+				() -> assertArrayEquals(new Long[] { 6L, 5L, 4L, 3L, 2L }, array)
+		);
+	}
+
+	@Test
+	void testToArrayShouldThrowWhenProvidedArrayIsBiggerThanInternalOne() {
+		CircularLossyQueue<Long> queue = new CircularLossyQueue<>(5);
+		Long[] array = new Long[10];
+
+		assertThrows(IllegalArgumentException.class, () -> queue.toArray(array));
+	}
+
+	@Test
+	void testToArray() {
+		CircularLossyQueue<Long> queue = new CircularLossyQueue<>(5);
+		Long[] array = new Long[5];
+
+		for (long value = 1L; value < 4L; value++) {
+			queue.push(value);
+		}
+
+		array = queue.toArray(array);
+		assertArrayEquals(new Long[] { 3L, 2L, 1L, null, null }, array);
+
+		for (long value = 4L; value < 9L; value++) {
+			queue.push(value);
+		}
+
+		array = queue.toArray(array);
+		assertArrayEquals(new Long[] { 8L, 7L, 6L, 5L, 4L }, array);
+
+	}
+
+}


### PR DESCRIPTION
This PR will fix possible array index overflow in CircularLossyQueue

## Changes
-

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [x] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

