### PR TITLE
Add Automatic-Module-Name attribute to jar manifest for better Java 9…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,8 @@ allprojects {
                         "Implementation-Vendor-Id": project.group,
                         "Implementation-Version": project.version,
                         "Built-By": System.getProperty("user.name"),
-                        "Built-JDK": System.getProperty("java.version")
+                        "Built-JDK": System.getProperty("java.version"),
+                        "Automatic-Module-Name": 'org.quartz'
                 )
             }
         }


### PR DESCRIPTION
…+ JPMS compatibility

<!--
If this is your first time contributing to the project (or it's been a while), please consider reviewing https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
-->

This PR adds Automatic-Module-Name attribute to jar manifest.

Fixes issue #1131

## Changes
- Adds Automatic-Module-Name attribute to jar manifest.

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

