### PR TITLE
Improve Singleton instantiation in SchedulerRepository

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/SchedulerRepository.java
+++ b/quartz/src/main/java/org/quartz/impl/SchedulerRepository.java
@@ -45,13 +45,11 @@ public class SchedulerRepository {
 
     private final HashMap<String, Scheduler> schedulers;
 
-    private static SchedulerRepository inst;
-
     /*
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     * 
+     *
      * Constructors.
-     * 
+     *
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      */
 
@@ -59,25 +57,24 @@ public class SchedulerRepository {
         schedulers = new HashMap<>();
     }
 
+    private static class Holder {
+        private static final SchedulerRepository INSTANCE = new SchedulerRepository();
+    }
     /*
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     * 
+     *
      * Interface.
-     * 
+     *
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      */
 
     public static synchronized SchedulerRepository getInstance() {
-        if (inst == null) {
-            inst = new SchedulerRepository();
-        }
-
-        return inst;
+        return Holder.INSTANCE;
     }
 
     public synchronized void bind(Scheduler sched) throws SchedulerException {
 
-        if ((Scheduler) schedulers.get(sched.getSchedulerName()) != null) {
+        if (schedulers.get(sched.getSchedulerName()) != null) {
             throw new SchedulerException("Scheduler with name '"
                     + sched.getSchedulerName() + "' already exists.");
         }


### PR DESCRIPTION
Refactored the Singleton pattern in SchedulerRepository to use the Bill Pugh Singleton Holder pattern for lazy initialization and thread safety without explicit synchronization. 

<!--
If this is your first time contributing to the project (or it's been a while), please consider reviewing https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
-->


This PR...

Fixes issue #

## Changes
- Refactored the Singleton pattern in SchedulerRepository

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

