### PR TITLE
restore osgi headers in manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,10 @@ allprojects {
                         "Implementation-Version": project.version,
                         "Built-By": System.getProperty("user.name"),
                         "Built-JDK": System.getProperty("java.version"),
-                        "Automatic-Module-Name": 'org.quartz'
+                        "Automatic-Module-Name": 'org.quartz',
+                        "-removeheaders": 'Private-Package',
+                        "Export-Package": 'org.quartz.*',
+                        "Import-Package": '*;resolution:=optional'
                 )
             }
         }

--- a/quartz-jobs/build.gradle
+++ b/quartz-jobs/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {

--- a/quartz/build.gradle
+++ b/quartz/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
+    id 'biz.aQute.bnd.builder'
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@
 pluginManagement {
     plugins {
         id("io.github.gradle-nexus.publish-plugin") version '2.0.0'
+        id ("biz.aQute.bnd.builder") version '6.4.0'
     }
 }
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project (or it's been a while), please consider reviewing https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
-->

quartz 2.3.x jar was osgified, through maven build.
osgi headers were lost switching to gradle
This PR restore osgi header in built jar manifest 

-----------------
## Checklist
- [X] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [X] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

