### PR TITLE
restore osgi headers in manifest (backport)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,10 @@ allprojects {
                         "Implementation-Vendor-Id": project.group,
                         "Implementation-Version": project.version,
                         "Built-By": System.getProperty("user.name"),
-                        "Built-JDK": System.getProperty("java.version")
+                        "Built-JDK": System.getProperty("java.version"),
+                        "-removeheaders": 'Private-Package',
+                        "Export-Package": 'org.quartz.*',
+                        "Import-Package": '*;resolution:=optional'
                 )
             }
         }

--- a/quartz-jobs/build.gradle
+++ b/quartz-jobs/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
+    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {

--- a/quartz/build.gradle
+++ b/quartz/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
+    id 'biz.aQute.bnd.builder'
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@
 pluginManagement {
     plugins {
         id("io.github.gradle-nexus.publish-plugin") version '2.0.0'
+        id ("biz.aQute.bnd.builder") version '6.4.0'
     }
 }
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project (or it's been a while), please consider reviewing https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
-->


This PR is a backport of commit restoring osgi manifest header in built jar

Fixes issue #

## Changes
-

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

