### PR TITLE
Fix #1095: 2.5 Check for MSSQLDelegate not full class name

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -663,7 +663,7 @@ public abstract class JobStoreSupport implements JobStore, Constants {
             }
             
             if (getUseDBLocks()) {
-                if(getDriverDelegateClass() != null && getDriverDelegateClass().contains("MSSQLDelegate")) {
+                if(getDriverDelegateClass() != null && getDriverDelegateClass().contains(MSSQLDelegate.class.getSimpleName())) {
                     if(getSelectWithLockSQL() == null) {
                         String msSqlDflt = "SELECT * FROM {0}LOCKS WITH (UPDLOCK,ROWLOCK) WHERE " + COL_SCHEDULER_NAME + " = {1} AND LOCK_NAME = ?";
                         getLog().info("Detected usage of MSSQLDelegate class - defaulting 'selectWithLockSQL' to '{}'.", msSqlDflt);


### PR DESCRIPTION
Quarkus used and extended MSSQLDelegate so it skips this code:
https://github.com/quarkusio/quarkus/blob/main/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/jdbc/QuarkusMSSQLDelegate.java

So we need to check for the "MSSQLDelegate" instead of the full class name. Ideally we should check for instanceof but it looks like this was intentional here using the String and before the Delegate Class is loaded

Fix #1095 
Fix #1101

cc @amergey
