### PR TITLE
Fix tomorrowAt returning wrong date when called before DST change

### DIFF
--- a/quartz/src/main/java/org/quartz/DateBuilder.java
+++ b/quartz/src/main/java/org/quartz/DateBuilder.java
@@ -1,63 +1,71 @@
 /*
  * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
  * Copyright Super iPaaS Integration LLC, an IBM Company 2024
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not 
- * use this file except in compliance with the License. You may obtain a copy 
- * of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- *   
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
- * 
+ *
  */
 
 package org.quartz;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Year;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
 /**
- * <code>DateBuilder</code> is used to conveniently create 
+ * <code>DateBuilder</code> is used to conveniently create
  * <code>java.util.Date</code> instances that meet particular criteria.
- *  
+ *
  * <p>Quartz provides a builder-style API for constructing scheduling-related
  * entities via a Domain-Specific Language (DSL).  The DSL can best be
  * utilized through the usage of static imports of the methods on the classes
- * <code>TriggerBuilder</code>, <code>JobBuilder</code>, 
- * <code>DateBuilder</code>, <code>JobKey</code>, <code>TriggerKey</code> 
+ * <code>TriggerBuilder</code>, <code>JobBuilder</code>,
+ * <code>DateBuilder</code>, <code>JobKey</code>, <code>TriggerKey</code>
  * and the various <code>ScheduleBuilder</code> implementations.</p>
- * 
+ *
  * <p>Client code can then use the DSL to write code such as this:</p>
  * <pre>
  *         JobDetail job = newJob(MyJob.class)
  *             .withIdentity("myJob")
  *             .build();
- *             
- *         Trigger trigger = newTrigger() 
+ *
+ *         Trigger trigger = newTrigger()
  *             .withIdentity(triggerKey("myTrigger", "myTriggerGroup"))
  *             .withSchedule(simpleSchedule()
  *                 .withIntervalInHours(1)
  *                 .repeatForever())
  *             .startAt(futureDate(10, MINUTES))
  *             .build();
- *         
+ *
  *         scheduler.scheduleJob(job, trigger);
  * </pre>
- *  
+ *
  * @see TriggerBuilder
- * @see JobBuilder 
+ * @see JobBuilder
  */
 public class DateBuilder {
 
     public enum IntervalUnit { MILLISECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, YEAR }
-    
+
     public static final int SUNDAY = 1;
 
     public static final int MONDAY = 2;
@@ -71,9 +79,9 @@ public class DateBuilder {
     public static final int FRIDAY = 6;
 
     public static final int SATURDAY = 7;
-    
+
     public static final int JANUARY = 1;
-    
+
     public static final int FEBRUARY = 2;
 
     public static final int MARCH = 3;
@@ -103,74 +111,51 @@ public class DateBuilder {
     public static final long SECONDS_IN_MOST_DAYS = 24L * 60L * 60L;
 
     public static final long MILLISECONDS_IN_DAY = SECONDS_IN_MOST_DAYS * 1000L;
-    
-    private int month;
-    private int day;
-    private int year;
-    private int hour;
-    private int minute;
-    private int second;
-    private TimeZone tz;
+
+    private int month = -1;
+    private int day = -1;
+    private int year = -1;
+    private int hour = -1;
+    private int minute = -1;
+    private int second = -1;
+    private ZoneId zoneId;
     private Locale lc;
-    
+    private Clock clock = Clock.systemDefaultZone();
+
     /**
      * Create a DateBuilder, with initial settings for the current date and time in the system default timezone.
      */
     private DateBuilder() {
-        Calendar cal = Calendar.getInstance();
-        
-        month = cal.get(Calendar.MONTH) + 1;
-        day = cal.get(Calendar.DAY_OF_MONTH);
-        year = cal.get(Calendar.YEAR);
-        hour = cal.get(Calendar.HOUR_OF_DAY);
-        minute = cal.get(Calendar.MINUTE);
-        second = cal.get(Calendar.SECOND);
+        this(TimeZone.getDefault());
     }
 
     /**
      * Create a DateBuilder, with initial settings for the current date and time in the given timezone.
      */
     private DateBuilder(TimeZone tz) {
-        Calendar cal = Calendar.getInstance(tz);
-        
-        this.tz = tz;
-        month = cal.get(Calendar.MONTH) + 1;
-        day = cal.get(Calendar.DAY_OF_MONTH);
-        year = cal.get(Calendar.YEAR);
-        hour = cal.get(Calendar.HOUR_OF_DAY);
-        minute = cal.get(Calendar.MINUTE);
-        second = cal.get(Calendar.SECOND);
+        this.zoneId = tz.toZoneId();
     }
 
     /**
      * Create a DateBuilder, with initial settings for the current date and time in the given locale.
      */
     private DateBuilder(Locale lc) {
-        Calendar cal = Calendar.getInstance(lc);
-        
+        this(Calendar.getInstance(lc).getTimeZone());
         this.lc = lc;
-        month = cal.get(Calendar.MONTH) + 1;
-        day = cal.get(Calendar.DAY_OF_MONTH);
-        year = cal.get(Calendar.YEAR);
-        hour = cal.get(Calendar.HOUR_OF_DAY);
-        minute = cal.get(Calendar.MINUTE);
-        second = cal.get(Calendar.SECOND);
     }
 
     /**
      * Create a DateBuilder, with initial settings for the current date and time in the given timezone and locale.
      */
     private DateBuilder(TimeZone tz, Locale lc) {
-        Calendar cal = Calendar.getInstance(tz, lc);
-        
-        this.tz = tz;
+        this(Calendar.getInstance(tz, lc).getTimeZone());
+
+        this.zoneId = tz.toZoneId();
         this.lc = lc;
-        month = cal.get(Calendar.MONTH) + 1;
-        day = cal.get(Calendar.DAY_OF_MONTH);
-        year = cal.get(Calendar.YEAR);
-        hour = cal.get(Calendar.HOUR_OF_DAY);
-        minute = cal.get(Calendar.MINUTE);
-        second = cal.get(Calendar.SECOND);
+    }
+
+    void setClock(Clock clock) {
+        this.clock = clock;
     }
 
     /**
@@ -202,37 +187,35 @@ public class DateBuilder {
     }
 
     /**
-     * Build the Date defined by this builder instance. 
+     * Build the Date defined by this builder instance.
      */
     public Date build() {
-        Calendar cal;
+        var useZoneId = (zoneId != null) ? zoneId : ZoneId.systemDefault();
+        if (lc != null && useZoneId == null) {
+            useZoneId = Calendar.getInstance(lc).getTimeZone().toZoneId();
+        }
 
-        if(tz != null && lc != null)
-            cal = Calendar.getInstance(tz, lc);
-        else if(tz != null)
-            cal = Calendar.getInstance(tz);
-        else if(lc != null)
-            cal = Calendar.getInstance(lc);
-        else 
-          cal = Calendar.getInstance();
-        
-        cal.set(Calendar.YEAR, year);
-        cal.set(Calendar.MONTH, month - 1);
-        cal.set(Calendar.DAY_OF_MONTH, day);
-        cal.set(Calendar.HOUR_OF_DAY, hour);
-        cal.set(Calendar.MINUTE, minute);
-        cal.set(Calendar.SECOND, second);
-        cal.set(Calendar.MILLISECOND, 0);
-        
-        return cal.getTime();
+        if (year == -1 || month == -1 || day == -1 || hour == -1 || minute == -1 || second == -1) {
+            var zdt = ZonedDateTime.now(clock).withZoneSameInstant(useZoneId);
+
+            year = zdt.getYear();
+            month = zdt.getMonthValue();
+            day = zdt.getDayOfMonth();
+            hour = zdt.getHour();
+            minute = zdt.getMinute();
+            second = zdt.getSecond();
+        }
+        var zdt = ZonedDateTime.of(year, month, day, hour, minute, second, 0, useZoneId);
+
+        return Date.from(zdt.toInstant());
     }
-    
+
     /**
      * Set the hour (0-23) for the Date that will be built by this builder.
      */
     public DateBuilder atHourOfDay(int atHour) {
         validateHour(atHour);
-        
+
         this.hour = atHour;
         return this;
     }
@@ -242,7 +225,7 @@ public class DateBuilder {
      */
     public DateBuilder atMinute(int atMinute) {
         validateMinute(atMinute);
-        
+
         this.minute = atMinute;
         return this;
     }
@@ -252,7 +235,7 @@ public class DateBuilder {
      */
     public DateBuilder atSecond(int atSecond) {
         validateSecond(atSecond);
-        
+
         this.second = atSecond;
         return this;
     }
@@ -261,19 +244,19 @@ public class DateBuilder {
         validateHour(atHour);
         validateMinute(atMinute);
         validateSecond(atSecond);
-        
+
         this.hour = atHour;
         this.second = atSecond;
         this.minute = atMinute;
         return this;
     }
-    
+
     /**
      * Set the day of month (1-31) for the Date that will be built by this builder.
      */
     public DateBuilder onDay(int onDay) {
         validateDayOfMonth(onDay);
-        
+
         this.day = onDay;
         return this;
     }
@@ -283,15 +266,15 @@ public class DateBuilder {
      */
     public DateBuilder inMonth(int inMonth) {
         validateMonth(inMonth);
-        
+
         this.month = inMonth;
         return this;
     }
-    
+
     public DateBuilder inMonthOnDay(int inMonth, int onDay) {
         validateMonth(inMonth);
         validateDayOfMonth(onDay);
-        
+
         this.month = inMonth;
         this.day = onDay;
         return this;
@@ -302,7 +285,7 @@ public class DateBuilder {
      */
     public DateBuilder inYear(int inYear) {
         validateYear(inYear);
-        
+
         this.year = inYear;
         return this;
     }
@@ -311,7 +294,7 @@ public class DateBuilder {
      * Set the TimeZone for the Date that will be built by this builder (if "null", system default will be used)
      */
     public DateBuilder inTimeZone(TimeZone timezone) {
-        this.tz = timezone;
+        this.zoneId = timezone.toZoneId();
         return this;
     }
 
@@ -324,27 +307,23 @@ public class DateBuilder {
     }
 
     public static Date futureDate(int interval, IntervalUnit unit) {
-        
-        Calendar c = Calendar.getInstance();
-        c.setTime(new Date());
-        c.setLenient(true);
-        
-        c.add(translate(unit), interval);
-
-        return c.getTime();
+        return futureDate(interval, unit, Clock.systemDefaultZone());
     }
-    
 
-    private static int translate(IntervalUnit unit) {
-        switch(unit) {
-            case DAY : return Calendar.DAY_OF_YEAR;
-            case HOUR : return Calendar.HOUR_OF_DAY;
-            case MINUTE : return Calendar.MINUTE;
-            case MONTH : return Calendar.MONTH;
-            case SECOND : return Calendar.SECOND;
-            case MILLISECOND : return Calendar.MILLISECOND;
-            case WEEK : return Calendar.WEEK_OF_YEAR;
-            case YEAR : return Calendar.YEAR;
+    static Date futureDate(int interval, IntervalUnit unit, Clock clock) {
+        return Date.from(ZonedDateTime.now(clock).plus(interval, translate(unit)).toInstant());
+    }
+
+    private static ChronoUnit translate(IntervalUnit unit) {
+        switch (unit) {
+            case DAY : return ChronoUnit.DAYS;
+            case HOUR : return ChronoUnit.HOURS;
+            case MINUTE : return ChronoUnit.MINUTES;
+            case MONTH : return ChronoUnit.MONTHS;
+            case SECOND : return ChronoUnit.SECONDS;
+            case MILLISECOND : return ChronoUnit.MILLIS;
+            case WEEK : return ChronoUnit.WEEKS;
+            case YEAR : return ChronoUnit.YEARS;
             default : throw new IllegalArgumentException("Unknown IntervalUnit");
         }
     }
@@ -354,35 +333,26 @@ public class DateBuilder {
      * Get a <code>Date</code> object that represents the given time, on
      * tomorrow's date.
      * </p>
-     * 
-     * @param second
-     *          The value (0-59) to give the seconds field of the date
-     * @param minute
-     *          The value (0-59) to give the minutes field of the date
+     *
      * @param hour
      *          The value (0-23) to give the hours field of the date
+     * @param minute
+     *          The value (0-59) to give the minutes field of the date
+     * @param second
+     *          The value (0-59) to give the seconds field of the date
      * @return the new date
      */
     public static Date tomorrowAt(int hour, int minute, int second) {
-        validateSecond(second);
-        validateMinute(minute);
-        validateHour(hour);
+        return tomorrowAt(hour, minute, second, Clock.systemDefaultZone());
+    }
 
-        Date date = new Date();
-
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-        c.setLenient(true);
-
-        // advance one day
-        c.add(Calendar.DAY_OF_YEAR, 1);
-        
-        c.set(Calendar.HOUR_OF_DAY, hour);
-        c.set(Calendar.MINUTE, minute);
-        c.set(Calendar.SECOND, second);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+    static Date tomorrowAt(int hour, int minute, int second, Clock clock) {
+        return Date.from(
+                ZonedDateTime.now(clock)
+                        .truncatedTo(ChronoUnit.DAYS)
+                        .plusHours(24)
+                        .with(LocalTime.of(hour, minute, second, 0))
+                        .toInstant());
     }
 
     /**
@@ -390,50 +360,46 @@ public class DateBuilder {
      * Get a <code>Date</code> object that represents the given time, on
      * today's date (equivalent to {@link #dateOf(int, int, int)}).
      * </p>
-     * 
-     * @param second
-     *          The value (0-59) to give the seconds field of the date
-     * @param minute
-     *          The value (0-59) to give the minutes field of the date
+     *
      * @param hour
      *          The value (0-23) to give the hours field of the date
+     * @param minute
+     *          The value (0-59) to give the minutes field of the date
+     * @param second
+     *          The value (0-59) to give the seconds field of the date
      * @return the new date
      */
     public static Date todayAt(int hour, int minute, int second) {
-        return dateOf(hour, minute, second);
+        return todayAt(hour, minute, second, Clock.systemDefaultZone());
     }
-    
+
+    static Date todayAt(int hour, int minute, int second, Clock clock) {
+        return dateOf(hour, minute, second, clock);
+    }
+
     /**
      * <p>
      * Get a <code>Date</code> object that represents the given time, on
      * today's date  (equivalent to {@link #todayAt(int, int, int)}).
      * </p>
-     * 
-     * @param second
-     *          The value (0-59) to give the seconds field of the date
-     * @param minute
-     *          The value (0-59) to give the minutes field of the date
+     *
      * @param hour
      *          The value (0-23) to give the hours field of the date
+     * @param minute
+     *          The value (0-59) to give the minutes field of the date
+     * @param second
+     *          The value (0-59) to give the seconds field of the date
      * @return the new date
      */
     public static Date dateOf(int hour, int minute, int second) {
-        validateSecond(second);
-        validateMinute(minute);
-        validateHour(hour);
+        return dateOf(hour, minute, second, Clock.systemDefaultZone());
+    }
 
-        Date date = new Date();
-
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-        c.setLenient(true);
-
-        c.set(Calendar.HOUR_OF_DAY, hour);
-        c.set(Calendar.MINUTE, minute);
-        c.set(Calendar.SECOND, second);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+    static Date dateOf(int hour, int minute, int second, Clock clock) {
+        return Date.from(
+                ZonedDateTime.now(clock)
+                        .with(LocalTime.of(hour, minute, second, 0))
+                        .toInstant());
     }
 
     /**
@@ -441,13 +407,13 @@ public class DateBuilder {
      * Get a <code>Date</code> object that represents the given time, on the
      * given date.
      * </p>
-     * 
-     * @param second
-     *          The value (0-59) to give the seconds field of the date
-     * @param minute
-     *          The value (0-59) to give the minutes field of the date
+     *
      * @param hour
      *          The value (0-23) to give the hours field of the date
+     * @param minute
+     *          The value (0-59) to give the minutes field of the date
+     * @param second
+     *          The value (0-59) to give the seconds field of the date
      * @param dayOfMonth
      *          The value (1-31) to give the day of month field of the date
      * @param month
@@ -456,25 +422,15 @@ public class DateBuilder {
      */
     public static Date dateOf(int hour, int minute, int second,
             int dayOfMonth, int month) {
-        validateSecond(second);
-        validateMinute(minute);
-        validateHour(hour);
-        validateDayOfMonth(dayOfMonth);
-        validateMonth(month);
+        return dateOf(hour, minute, second, dayOfMonth, month, Clock.systemDefaultZone());
+    }
 
-        Date date = new Date();
-
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-
-        c.set(Calendar.MONTH, month - 1);
-        c.set(Calendar.DAY_OF_MONTH, dayOfMonth);
-        c.set(Calendar.HOUR_OF_DAY, hour);
-        c.set(Calendar.MINUTE, minute);
-        c.set(Calendar.SECOND, second);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+    static Date dateOf(int hour, int minute, int second,
+            int dayOfMonth, int month, Clock clock) {
+        var zdt = ZonedDateTime.now(clock);
+        return Date.from(
+                zdt.with(LocalDateTime.of(zdt.getYear(), month, dayOfMonth, hour, minute, second, 0))
+                        .toInstant());
     }
 
     /**
@@ -482,95 +438,83 @@ public class DateBuilder {
      * Get a <code>Date</code> object that represents the given time, on the
      * given date.
      * </p>
-     * 
-     * @param second
-     *          The value (0-59) to give the seconds field of the date
-     * @param minute
-     *          The value (0-59) to give the minutes field of the date
+     *
      * @param hour
      *          The value (0-23) to give the hours field of the date
+     * @param minute
+     *          The value (0-59) to give the minutes field of the date
+     * @param second
+     *          The value (0-59) to give the seconds field of the date
      * @param dayOfMonth
      *          The value (1-31) to give the day of month field of the date
      * @param month
      *          The value (1-12) to give the month field of the date
      * @param year
-     *          The value (1970-2099) to give the year field of the date
+     *          The value (1970-999999999) to give the year field of the date
      * @return the new date
      */
     public static Date dateOf(int hour, int minute, int second,
             int dayOfMonth, int month, int year) {
-        validateSecond(second);
-        validateMinute(minute);
-        validateHour(hour);
-        validateDayOfMonth(dayOfMonth);
-        validateMonth(month);
-        validateYear(year);
-
-        Date date = new Date();
-
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-
-        c.set(Calendar.YEAR, year);
-        c.set(Calendar.MONTH, month - 1);
-        c.set(Calendar.DAY_OF_MONTH, dayOfMonth);
-        c.set(Calendar.HOUR_OF_DAY, hour);
-        c.set(Calendar.MINUTE, minute);
-        c.set(Calendar.SECOND, second);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+        return dateOf(hour, minute, second, dayOfMonth, month, year, Clock.systemDefaultZone());
     }
 
+    static Date dateOf(int hour, int minute, int second,
+            int dayOfMonth, int month, int year, Clock clock) {
+        return Date.from(
+                LocalDateTime.of(year, month, dayOfMonth, hour, minute, second, 0)
+                        .atZone(clock.getZone())
+                        .toInstant());
+    }
 
     /**
      * <p>
      * Returns a date that is rounded to the next even hour after the current time.
      * </p>
-     * 
+     *
      * <p>
      * For example a current time of 08:13:54 would result in a date
      * with the time of 09:00:00. If the date's time is in the 23rd hour, the
      * date's 'day' will be promoted, and the time will be set to 00:00:00.
      * </p>
-     * 
+     *
      * @return the new rounded date
      */
     public static Date evenHourDateAfterNow() {
-        return evenHourDate(null);
+        return evenHourDateAfterNow(Clock.systemDefaultZone());
     }
+
+    static Date evenHourDateAfterNow(Clock clock) {
+        return evenHourDate(null, clock);
+    }
+
     /**
      * <p>
      * Returns a date that is rounded to the next even hour above the given
      * date.
      * </p>
-     * 
+     *
      * <p>
      * For example an input date with a time of 08:13:54 would result in a date
      * with the time of 09:00:00. If the date's time is in the 23rd hour, the
      * date's 'day' will be promoted, and the time will be set to 00:00:00.
      * </p>
-     * 
+     *
      * @param date
      *          the Date to round, if <code>null</code> the current time will
      *          be used
      * @return the new rounded date
      */
     public static Date evenHourDate(Date date) {
-        if (date == null) {
-            date = new Date();
-        }
+        return evenHourDate(date, Clock.systemDefaultZone());
+    }
 
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-        c.setLenient(true);
+    static Date evenHourDate(Date date, Clock clock) {
+        var zdt = (date == null) ? ZonedDateTime.now(clock) : ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
 
-        c.set(Calendar.HOUR_OF_DAY, c.get(Calendar.HOUR_OF_DAY) + 1);
-        c.set(Calendar.MINUTE, 0);
-        c.set(Calendar.SECOND, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+        zdt = zdt.plusHours(1);
+        return Date.from(
+                zdt.truncatedTo(ChronoUnit.HOURS)
+                        .toInstant());
     }
 
     /**
@@ -578,146 +522,139 @@ public class DateBuilder {
      * Returns a date that is rounded to the previous even hour below the given
      * date.
      * </p>
-     * 
+     *
      * <p>
      * For example an input date with a time of 08:13:54 would result in a date
      * with the time of 08:00:00.
      * </p>
-     * 
+     *
      * @param date
      *          the Date to round, if <code>null</code> the current time will
      *          be used
      * @return the new rounded date
      */
     public static Date evenHourDateBefore(Date date) {
-        if (date == null) {
-            date = new Date();
-        }
+        return evenHourDateBefore(date, Clock.systemDefaultZone());
+    }
 
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
+    static Date evenHourDateBefore(Date date, Clock clock) {
+        var zdt = (date == null) ? ZonedDateTime.now(clock) : ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
 
-        c.set(Calendar.MINUTE, 0);
-        c.set(Calendar.SECOND, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+        return Date.from(
+                zdt.truncatedTo(ChronoUnit.HOURS)
+                        .toInstant());
     }
 
     /**
      * <p>
      * Returns a date that is rounded to the next even minute after the current time.
      * </p>
-     * 
+     *
      * <p>
      * For example a current time of 08:13:54 would result in a date
      * with the time of 08:14:00. If the date's time is in the 59th minute,
      * then the hour (and possibly the day) will be promoted.
      * </p>
-     * 
+     *
      * @return the new rounded date
      */
     public static Date evenMinuteDateAfterNow() {
-        return evenMinuteDate(null);
+        return evenMinuteDateAfterNow(Clock.systemDefaultZone());
     }
-    
+
+    static Date evenMinuteDateAfterNow(Clock clock) {
+        return evenMinuteDate(null, clock);
+    }
+
     /**
      * <p>
      * Returns a date that is rounded to the next even minute above the given
      * date.
      * </p>
-     * 
+     *
      * <p>
      * For example an input date with a time of 08:13:54 would result in a date
      * with the time of 08:14:00. If the date's time is in the 59th minute,
      * then the hour (and possibly the day) will be promoted.
      * </p>
-     * 
+     *
      * @param date
      *          the Date to round, if <code>null</code> the current time will
      *          be used
      * @return the new rounded date
      */
     public static Date evenMinuteDate(Date date) {
-        if (date == null) {
-            date = new Date();
-        }
+        return evenMinuteDate(date, Clock.systemDefaultZone());
+    }
 
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-        c.setLenient(true);
+    public static Date evenMinuteDate(Date date, Clock clock) {
+        var zdt = (date == null) ? ZonedDateTime.now(clock) : ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
 
-        c.set(Calendar.MINUTE, c.get(Calendar.MINUTE) + 1);
-        c.set(Calendar.SECOND, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+        zdt = zdt.plusMinutes(1);
+        return Date.from(zdt.truncatedTo(ChronoUnit.MINUTES).toInstant());
     }
 
     /**
      * <p>
-     * Returns a date that is rounded to the previous even minute below the 
+     * Returns a date that is rounded to the previous even minute below the
      * given date.
      * </p>
-     * 
+     *
      * <p>
      * For example an input date with a time of 08:13:54 would result in a date
      * with the time of 08:13:00.
      * </p>
-     * 
+     *
      * @param date
      *          the Date to round, if <code>null</code> the current time will
      *          be used
      * @return the new rounded date
      */
     public static Date evenMinuteDateBefore(Date date) {
-        if (date == null) {
-            date = new Date();
-        }
+        return evenMinuteDateBefore(date, Clock.systemDefaultZone());
+    }
 
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
+    static Date evenMinuteDateBefore(Date date, Clock clock) {
+        var zdt = (date == null) ? ZonedDateTime.now(clock) : ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
 
-        c.set(Calendar.SECOND, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+        return Date.from(zdt.truncatedTo(ChronoUnit.MINUTES).toInstant());
     }
 
     /**
      * <p>
      * Returns a date that is rounded to the next even second after the current time.
      * </p>
-     * 
+     *
      * @return the new rounded date
      */
     public static Date evenSecondDateAfterNow() {
-        return evenSecondDate(null);
+        return evenSecondDateAfterNow(Clock.systemDefaultZone());
     }
+
+    static Date evenSecondDateAfterNow(Clock clock) {
+        return evenSecondDate(null, clock);
+    }
+
     /**
      * <p>
      * Returns a date that is rounded to the next even second above the given
      * date.
      * </p>
-     * 
+     *
      * @param date
      *          the Date to round, if <code>null</code> the current time will
      *          be used
      * @return the new rounded date
      */
     public static Date evenSecondDate(Date date) {
-        if (date == null) {
-            date = new Date();
-        }
+        return evenSecondDate(date, Clock.systemDefaultZone());
+    }
 
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-        c.setLenient(true);
+    static Date evenSecondDate(Date date, Clock clock) {
+        var zdt = (date == null) ? ZonedDateTime.now(clock) : ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
 
-        c.set(Calendar.SECOND, c.get(Calendar.SECOND) + 1);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+        zdt = zdt.plusSeconds(1);
+        return Date.from(zdt.truncatedTo(ChronoUnit.SECONDS).toInstant());
     }
 
     /**
@@ -725,36 +662,33 @@ public class DateBuilder {
      * Returns a date that is rounded to the previous even second below the
      * given date.
      * </p>
-     * 
+     *
      * <p>
      * For example an input date with a time of 08:13:54.341 would result in a
      * date with the time of 08:13:54.000.
      * </p>
-     * 
+     *
      * @param date
      *          the Date to round, if <code>null</code> the current time will
      *          be used
      * @return the new rounded date
      */
     public static Date evenSecondDateBefore(Date date) {
-        if (date == null) {
-            date = new Date();
-        }
-
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+        return evenSecondDateBefore(date, Clock.systemDefaultZone());
     }
-    
+
+    static Date evenSecondDateBefore(Date date, Clock clock) {
+        var zdt = (date == null) ? ZonedDateTime.now(clock) : ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
+
+        return Date.from(zdt.truncatedTo(ChronoUnit.SECONDS).toInstant());
+    }
+
     /**
      * <p>
      * Returns a date that is rounded to the next even multiple of the given
      * minute.
      * </p>
-     * 
+     *
      * <p>
      * For example an input date with a time of 08:13:54, and an input
      * minute-base of 5 would result in a date with the time of 08:15:00. The
@@ -763,7 +697,7 @@ public class DateBuilder {
      * input minute-base of 45 would result in 09:00:00, because the even-hour
      * is the next 'base' for 45-minute intervals.
      * </p>
-     * 
+     *
      * <p>
      * More examples:
      * </p>
@@ -835,70 +769,54 @@ public class DateBuilder {
      * <td>11:08:00</td>
      * </tr>
      * </table>
-     * 
+     *
      * @param date
      *          the Date to round, if <code>null</code> the current time will
      *          be used
      * @param minuteBase
      *          the base-minute to set the time on
      * @return the new rounded date
-     * 
+     *
      * @see #nextGivenSecondDate(Date, int)
      */
     public static Date nextGivenMinuteDate(Date date, int minuteBase) {
+        return nextGivenMinuteDate(date, minuteBase, Clock.systemDefaultZone());
+    }
+
+    static Date nextGivenMinuteDate(Date date, int minuteBase, Clock clock) {
         if (minuteBase < 0 || minuteBase > 59) {
             throw new IllegalArgumentException(
                     "minuteBase must be >=0 and <= 59");
         }
 
-        if (date == null) {
-            date = new Date();
-        }
-
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-        c.setLenient(true);
-
+        var zdt = (date == null) ? ZonedDateTime.now(clock) : ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
         if (minuteBase == 0) {
-            c.set(Calendar.HOUR_OF_DAY, c.get(Calendar.HOUR_OF_DAY) + 1);
-            c.set(Calendar.MINUTE, 0);
-            c.set(Calendar.SECOND, 0);
-            c.set(Calendar.MILLISECOND, 0);
-
-            return c.getTime();
+            zdt = zdt.truncatedTo(ChronoUnit.HOURS).plusHours(1);
+            return Date.from(zdt.toInstant());
         }
 
-        int minute = c.get(Calendar.MINUTE);
+        zdt = zdt.truncatedTo(ChronoUnit.MINUTES);
+        int minute = zdt.getMinute();
+        int nextminute = minute + minuteBase - (minute % minuteBase);
 
-        int arItr = minute / minuteBase;
-
-        int nextMinuteOccurrence = minuteBase * (arItr + 1);
-
-        if (nextMinuteOccurrence < 60) {
-            c.set(Calendar.MINUTE, nextMinuteOccurrence);
-            c.set(Calendar.SECOND, 0);
-            c.set(Calendar.MILLISECOND, 0);
-
-            return c.getTime();
+        if (nextminute >= 60) {
+            zdt = zdt.truncatedTo(ChronoUnit.HOURS).plusHours(1);
         } else {
-            c.set(Calendar.HOUR_OF_DAY, c.get(Calendar.HOUR_OF_DAY) + 1);
-            c.set(Calendar.MINUTE, 0);
-            c.set(Calendar.SECOND, 0);
-            c.set(Calendar.MILLISECOND, 0);
-
-            return c.getTime();
+            zdt = zdt.withMinute(nextminute);
         }
+
+        return Date.from(zdt.toInstant());
     }
-    
+
     /**
      * <p>
      * Returns a date that is rounded to the next even multiple of the given
-     * minute.
+     * second.
      * </p>
-     * 
+     *
      * <p>
      * The rules for calculating the second are the same as those for
-     * calculating the minute in the method 
+     * calculating the minute in the method
      * <code>getNextGivenMinuteDate(..)</code>.
      * </p>
      *
@@ -906,74 +824,58 @@ public class DateBuilder {
      * be used
      * @param secondBase the base-second to set the time on
      * @return the new rounded date
-     * 
+     *
      * @see #nextGivenMinuteDate(Date, int)
      */
     public static Date nextGivenSecondDate(Date date, int secondBase) {
+        return nextGivenSecondDate(date, secondBase, Clock.systemDefaultZone());
+    }
+
+    static Date nextGivenSecondDate(Date date, int secondBase, Clock clock) {
         if (secondBase < 0 || secondBase > 59) {
             throw new IllegalArgumentException(
                     "secondBase must be >=0 and <= 59");
         }
 
-        if (date == null) {
-            date = new Date();
-        }
-
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-        c.setLenient(true);
-
+        var zdt = (date == null) ? ZonedDateTime.now(clock) : ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
         if (secondBase == 0) {
-            c.set(Calendar.MINUTE, c.get(Calendar.MINUTE) + 1);
-            c.set(Calendar.SECOND, 0);
-            c.set(Calendar.MILLISECOND, 0);
-
-            return c.getTime();
+            zdt = zdt.truncatedTo(ChronoUnit.MINUTES).plusMinutes(1);
+            return Date.from(zdt.toInstant());
         }
 
-        int second = c.get(Calendar.SECOND);
+        zdt = zdt.truncatedTo(ChronoUnit.SECONDS);
+        int second = zdt.getSecond();
+        int nextSecond = second + secondBase - (second % secondBase);
 
-        int arItr = second / secondBase;
-
-        int nextSecondOccurrence = secondBase * (arItr + 1);
-
-        if (nextSecondOccurrence < 60) {
-            c.set(Calendar.SECOND, nextSecondOccurrence);
-            c.set(Calendar.MILLISECOND, 0);
-
-            return c.getTime();
+        if (nextSecond >= 60) {
+            zdt = zdt.truncatedTo(ChronoUnit.MINUTES).plusMinutes(1);
         } else {
-            c.set(Calendar.MINUTE, c.get(Calendar.MINUTE) + 1);
-            c.set(Calendar.SECOND, 0);
-            c.set(Calendar.MILLISECOND, 0);
-
-            return c.getTime();
+            zdt = zdt.withSecond(nextSecond);
         }
+
+        return Date.from(zdt.toInstant());
     }
 
     /**
      * Translate a date and time from a users time zone to the another
-     * (probably server) time zone to assist in creating a simple trigger with 
+     * (probably server) time zone to assist in creating a simple trigger with
      * the right date and time.
-     * 
+     *
      * @param date the date to translate
      * @param src the original time-zone
      * @param dest the destination time-zone
      * @return the translated date
      */
     public static Date translateTime(Date date, TimeZone src, TimeZone dest) {
-
         Date newDate = new Date();
-
         int offset = (dest.getOffset(date.getTime()) - src.getOffset(date.getTime()));
-
         newDate.setTime(date.getTime() - offset);
 
         return newDate;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     public static void validateDayOfWeek(int dayOfWeek) {
         if (dayOfWeek < SUNDAY || dayOfWeek > SATURDAY) {
             throw new IllegalArgumentException("Invalid day of week.");
@@ -1014,11 +916,10 @@ public class DateBuilder {
         }
     }
 
-    private static final int MAX_YEAR = Calendar.getInstance().get(Calendar.YEAR) + 100;
     public static void validateYear(int year) {
-        if (year < 0 || year > MAX_YEAR) {
+        if (year < 1970 || year > Year.MAX_VALUE) {
             throw new IllegalArgumentException(
-                    "Invalid year (must be >= 0 and <= " + MAX_YEAR);
+                    "Invalid year (must be >= 0 and <= " + Year.MAX_VALUE);
         }
     }
 

--- a/quartz/src/test/java/org/quartz/DateBuilderTest.java
+++ b/quartz/src/test/java/org/quartz/DateBuilderTest.java
@@ -1,57 +1,588 @@
 package org.quartz;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.quartz.DateBuilder.JULY;
+import static org.quartz.DateBuilder.JUNE;
+import static org.quartz.DateBuilder.dateOf;
+import static org.quartz.DateBuilder.futureDate;
+import static org.quartz.DateBuilder.newDate;
+import static org.quartz.DateBuilder.newDateInLocale;
+import static org.quartz.DateBuilder.newDateInTimeZoneAndLocale;
+import static org.quartz.DateBuilder.newDateInTimezone;
+import static org.quartz.DateBuilder.todayAt;
+import static org.quartz.DateBuilder.translateTime;
 
-import java.util.Date;
+import java.time.Clock;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.quartz.DateBuilder.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.quartz.DateBuilder.IntervalUnit;
 
-/**
- * Unit test for JobDetail.
- */
 class DateBuilderTest {
 
-    void testBasicBuilding() {
-        Date t = dateOf(10, 30, 0, 1, 7, 2013);  // july 1 10:30:00 am
+    @Test
+    void testJustInstantiatedBuilderShouldReturnSameInstantTruncatedToSeconds() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T10:15:30.999Z"), ZoneOffset.UTC);
+        var builder = DateBuilder.newDate();
+        builder.setClock(clock);
 
-        Calendar vc = Calendar.getInstance();
-        vc.set(Calendar.YEAR, 2013);
-        vc.set(Calendar.MONTH, Calendar.JULY);
-        vc.set(Calendar.DAY_OF_MONTH, 1);
-        vc.set(Calendar.HOUR_OF_DAY, 10);
-        vc.set(Calendar.MINUTE, 30);
-        vc.set(Calendar.SECOND, 0);
-        vc.set(Calendar.MILLISECOND, 0);
-
-        Date v = vc.getTime();
-        assertEquals(t, v, "DateBuilder-produced date is not as expected.");
+        assertEquals(Date.from(Instant.parse("2007-12-03T10:15:30.000Z")), builder.build());
     }
 
     @Test
     void testBuilder() {
-        Calendar vc = Calendar.getInstance();
-        vc.set(Calendar.YEAR, 2013);
-        vc.set(Calendar.MONTH, Calendar.JULY);
-        vc.set(Calendar.DAY_OF_MONTH, 1);
-        vc.set(Calendar.HOUR_OF_DAY, 10);
-        vc.set(Calendar.MINUTE, 30);
-        vc.set(Calendar.SECOND, 0);
-        vc.set(Calendar.MILLISECOND, 0);
+        var expected = ZonedDateTime.of(2013, 07, 1, 10, 30, 0, 0, ZoneId.systemDefault()).toInstant();
 
-        Date bd = newDate().inYear(2013).inMonth(JULY).onDay(1).atHourOfDay(10).atMinute(30).atSecond(0).build();
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
+        var bd1 = newDate().inYear(2013).inMonth(JULY).onDay(1).atHourOfDay(10).atMinute(30).atSecond(0).build();
+        var bd2 = newDate().inYear(2013).inMonthOnDay(JULY, 1).atHourMinuteAndSecond(10, 30, 0).build();
 
-        bd = newDate().inYear(2013).inMonthOnDay(JULY, 1).atHourMinuteAndSecond(10, 30, 0).build();
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
+        assertAll(
+                "dateBuilderDefaultTimeZone",
+                () -> assertEquals(expected, bd1.toInstant()),
+                () -> assertEquals(expected, bd2.toInstant()));
+    }
 
+    @Test
+    void testBuilderWithTimeZone() {
         TimeZone tz = TimeZone.getTimeZone("GMT-4:00");
+        var expected = Instant.parse("2013-06-01T14:33:12.000Z");
+
         Locale lz = Locale.TAIWAN;
-        vc = Calendar.getInstance(tz, lz);
+
+        var bd1 = newDate().inYear(2013)
+                .inMonth(JUNE)
+                .onDay(1)
+                .atHourOfDay(10)
+                .atMinute(33)
+                .atSecond(12)
+                .inTimeZone(tz)
+                .inLocale(lz)
+                .build();
+
+        var bd2 = newDateInLocale(lz).inYear(2013)
+                .inMonth(JUNE)
+                .onDay(1)
+                .atHourOfDay(10)
+                .atMinute(33)
+                .atSecond(12)
+                .inTimeZone(tz)
+                .build();
+
+        var bd3 = newDateInTimezone(tz).inYear(2013)
+                .inMonth(JUNE)
+                .onDay(1)
+                .atHourOfDay(10)
+                .atMinute(33)
+                .atSecond(12)
+                .inLocale(lz)
+                .build();
+
+        var bd4 = newDateInTimeZoneAndLocale(tz, lz).inYear(2013)
+                .inMonth(JUNE)
+                .onDay(1)
+                .atHourOfDay(10)
+                .atMinute(33)
+                .atSecond(12)
+                .build();
+
+        assertAll(
+                "dateBuilderWithCustomTimeZone",
+                () -> assertEquals(expected, bd1.toInstant()),
+                () -> assertEquals(expected, bd2.toInstant()),
+                () -> assertEquals(expected, bd3.toInstant()),
+                () -> assertEquals(expected, bd4.toInstant()));
+    }
+
+    /*
+     * futureDate tests
+     */
+
+    private static Stream<Arguments> futureDateTestData() {
+        return Stream.of(
+                Arguments.of(1, IntervalUnit.MILLISECOND, "2007-12-03T10:15:30.001Z"),
+                Arguments.of(1, IntervalUnit.SECOND, "2007-12-03T10:15:31.000Z"),
+                Arguments.of(1, IntervalUnit.MINUTE, "2007-12-03T10:16:30.000Z"),
+                Arguments.of(1, IntervalUnit.HOUR, "2007-12-03T11:15:30.000Z"),
+                Arguments.of(1, IntervalUnit.DAY, "2007-12-04T10:15:30.000Z"),
+                Arguments.of(1, IntervalUnit.WEEK, "2007-12-10T10:15:30.000Z"),
+                Arguments.of(1, IntervalUnit.MONTH, "2008-01-03T10:15:30.000Z"),
+                Arguments.of(1, IntervalUnit.YEAR, "2008-12-03T10:15:30.000Z"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("futureDateTestData")
+    void testFutureDate(int interval, IntervalUnit unit, String expected) {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T10:15:30.000Z"), ZoneId.systemDefault());
+
+        assertEquals(Date.from(Instant.parse(expected)), futureDate(interval, unit, clock));
+    }
+
+    @ParameterizedTest
+    @MethodSource("futureDateTestData")
+    void testFutureDateWithNonDefaultZone(int interval, IntervalUnit unit, String expected) {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T10:15:30.000Z"), ZoneOffset.ofHoursMinutes(3, 15));
+
+        assertEquals(Date.from(Instant.parse(expected)), futureDate(interval, unit, clock));
+    }
+
+    /*
+     * tomorrowAt tests
+     */
+
+    private static Stream<Arguments> tomorrowAtTestData() {
+        return Stream.of(
+                Arguments.of("2024-10-25T23:59:30.999Z", ZoneOffset.UTC, "2024-10-26T02:30:20.000Z"),
+                Arguments.of(
+                        "2024-03-30T23:59:59.999+01:00",
+                        ZoneId.of("Europe/Vienna"),
+                        "2024-03-31T03:30:20.000+02:00"), // DST change skipped one hour
+                Arguments.of(
+                        "2024-10-26T23:59:59.999+01:00",
+                        ZoneId.of("Europe/Vienna"),
+                        "2024-10-27T02:30:20.000+01:00")); // DST change added one hour
+    }
+
+    @ParameterizedTest
+    @MethodSource("tomorrowAtTestData")
+    void testTomorrowAt(String input, ZoneId zoneId, String expected) {
+        var instant = ZonedDateTime.parse(input).toInstant();
+        var clock = Clock.fixed(instant, zoneId);
+        var tomorrow = DateBuilder.tomorrowAt(2, 30, 20, clock);
+
+        assertEquals(Date.from(ZonedDateTime.parse(expected).toInstant()), tomorrow);
+    }
+
+    /*
+     * todayAt tests
+     */
+
+    @ParameterizedTest
+    @MethodSource("testDateOf3PWithInvalidParametersTestData")
+    void testTodayAtInvalidValues(int hour, int minute, int second) {
+        assertThrows(DateTimeException.class, () -> todayAt(hour, minute, second));
+    }
+
+    @Test
+    void testTodayAt() {
+        var clock1 = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        var date1 = DateBuilder.todayAt(1, 1, 1, clock1);
+        var clock2 = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneId.of("Europe/Vienna"));
+        var date2 = DateBuilder.todayAt(1, 1, 1, clock2);
+        var clock3 = Clock.fixed(Instant.parse("2024-03-31T08:13:54.341Z"), ZoneId.of("Europe/Vienna"));
+        var dstSkippedHour = DateBuilder.todayAt(2, 30, 17, clock3); // DST change => skipped hour
+
+        assertAll(
+                "dateOf3P",
+                () -> assertNotEquals(date1, date2),
+                () -> assertEquals(Instant.parse("2007-12-03T01:01:01.000Z"), date1.toInstant()),
+                () -> assertEquals(Instant.parse("2007-12-03T00:01:01.000Z"), date2.toInstant()),
+                () -> assertEquals(
+                        ZonedDateTime.parse("2024-03-31T03:30:17.000+02:00")
+                                .toInstant(),
+                        dstSkippedHour.toInstant()));
+    }
+
+    /*
+     * dateOf tests
+     */
+
+    private static Stream<Arguments> testDateOf3PWithInvalidParametersTestData() {
+        return Stream.of(
+                Arguments.of(-1, 0, 0),
+                Arguments.of(24, 0, 0),
+                Arguments.of(0, -1, 0),
+                Arguments.of(0, 60, 0),
+                Arguments.of(0, 0, -1),
+                Arguments.of(0, 0, 60));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testDateOf3PWithInvalidParametersTestData")
+    void testDateOf3PWithInvalidParameters(int hour, int minute, int second) {
+        assertThrows(DateTimeException.class, () -> dateOf(hour, minute, second));
+    }
+
+    @Test
+    void testDateOf3P() {
+        var clock1 = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        var clock2 = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneId.of("Europe/Vienna"));
+        var date1 = DateBuilder.dateOf(1, 1, 1, clock1);
+        var date2 = DateBuilder.dateOf(1, 1, 1, clock2);
+        assertAll(
+                "dateOf3P",
+                () -> assertNotEquals(date1, date2),
+                () -> assertEquals(Instant.parse("2007-12-03T01:01:01.000Z"), date1.toInstant()),
+                () -> assertEquals(Instant.parse("2007-12-03T00:01:01.000Z"), date2.toInstant()));
+    }
+
+    private static Stream<Arguments> testDateOf5PWithInvalidParametersTestData() {
+        return Stream.of(
+                Arguments.of(-1, 0, 0, 0, 0),
+                Arguments.of(24, 0, 0, 0, 0),
+                Arguments.of(0, -1, 0, 0, 0),
+                Arguments.of(0, 60, 0, 0, 0),
+                Arguments.of(0, 0, -1, 0, 0),
+                Arguments.of(0, 0, 60, 0, 0),
+                Arguments.of(0, 0, 0, 0, 0),
+                Arguments.of(0, 0, 0, 32, 0),
+                Arguments.of(0, 0, 0, 0, 0),
+                Arguments.of(0, 0, 0, 0, 13),
+                Arguments.of(0, 0, 0, 0, 0),
+                Arguments.of(0, 0, 0, 0, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testDateOf5PWithInvalidParametersTestData")
+    void testDateOf5PWithInvalidParameters(int hour, int minute, int second,
+            int dayOfMonth, int month) {
+        assertThrows(DateTimeException.class, () -> dateOf(hour, minute, second, dayOfMonth, month));
+    }
+
+    @Test
+    void testDateOf5P() {
+        var clock1 = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        var clock2 = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneId.of("Europe/Vienna"));
+        var date1 = DateBuilder.dateOf(1, 1, 1, 1, 1, clock1);
+        var date2 = DateBuilder.dateOf(1, 1, 1, 1, 1, clock2);
+        assertAll(
+                "dateOf6P",
+                () -> assertNotEquals(date1, date2),
+                () -> assertEquals(Instant.parse("2007-01-01T01:01:01.000Z"), date1.toInstant()),
+                () -> assertEquals(Instant.parse("2007-01-01T00:01:01.000Z"), date2.toInstant()));
+    }
+
+    private static Stream<Arguments> testDateOf6PWithInvalidParametersTestData() {
+        return Stream.of(
+                Arguments.of(-1, 0, 0, 0, 0, 0),
+                Arguments.of(24, 0, 0, 0, 0, 0),
+                Arguments.of(0, -1, 0, 0, 0, 0),
+                Arguments.of(0, 60, 0, 0, 0, 0),
+                Arguments.of(0, 0, -1, 0, 0, 0),
+                Arguments.of(0, 0, 60, 0, 0, 0),
+                Arguments.of(0, 0, 0, 0, 0, 0),
+                Arguments.of(0, 0, 0, 32, 0, 0),
+                Arguments.of(0, 0, 0, 0, 0, 0),
+                Arguments.of(0, 0, 0, 0, 13, 0),
+                Arguments.of(0, 0, 0, 0, 0, -1_000_000_000),
+                Arguments.of(0, 0, 0, 0, 0, 1_000_000_000));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testDateOf6PWithInvalidParametersTestData")
+    void testDateOf6PWithInvalidParameters(int hour, int minute, int second,
+            int dayOfMonth, int month, int year) {
+        assertThrows(DateTimeException.class, () -> dateOf(hour, minute, second, dayOfMonth, month, year));
+    }
+
+    @Test
+    void testDateOf6P() {
+        var clock1 = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        var clock2 = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneId.of("Europe/Vienna"));
+        var date1 = DateBuilder.dateOf(1, 1, 1, 1, 1, 2024, clock1);
+        var date2 = DateBuilder.dateOf(1, 1, 1, 1, 1, 2024, clock2);
+        assertAll(
+                "dateOf6P",
+                () -> assertNotEquals(date1, date2),
+                () -> assertEquals(Instant.parse("2024-01-01T01:01:01.000Z"), date1.toInstant()),
+                () -> assertEquals(Instant.parse("2024-01-01T00:01:01.000Z"), date2.toInstant()));
+    }
+
+    /*
+     * evenHourDateAfterNow tests
+     */
+
+    @Test
+    void testEvenHourDateAfterNow() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        assertEquals(
+                Instant.parse("2007-12-03T09:00:00.000Z"),
+                DateBuilder.evenHourDateAfterNow(clock)
+                        .toInstant());
+    }
+
+    /*
+     * evenHourDate tests
+     */
+
+    @Test
+    void testEvenHourDate() {
+        assertEquals(
+                Instant.parse("2007-12-03T09:00:00.000Z"),
+                DateBuilder.evenHourDate(Date.from(Instant.parse("2007-12-03T08:13:54.341Z"))).toInstant());
+    }
+
+    @Test
+    void testEvenHourDateWithoutProvidedDateCurrentDateRoundedToSeconds() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        assertEquals(
+                Instant.parse("2007-12-03T09:00:00.000Z"),
+                DateBuilder.evenHourDate(null, clock)
+                        .toInstant());
+    }
+
+    /*
+     * evenHourDateBefore tests
+     */
+
+    @Test
+    void testEvenHourDateBefore() {
+        assertEquals(
+                Instant.parse("2007-12-03T08:00:00.000Z"),
+                DateBuilder.evenHourDateBefore(Date.from(Instant.parse("2007-12-03T08:13:54.341Z"))).toInstant());
+    }
+
+    @Test
+    void testEvenHourDateBeforeWithoutProvidedDateCurrentDateRoundedToSeconds() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        assertEquals(
+                Instant.parse("2007-12-03T08:00:00.000Z"),
+                DateBuilder.evenHourDateBefore(null, clock)
+                        .toInstant());
+    }
+
+    /*
+     * evenMinuteDateAfterNow tests
+     */
+
+    @Test
+    void testEvenMinuteDateAfterNow() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        assertEquals(
+                Instant.parse("2007-12-03T08:14:00.000Z"),
+                DateBuilder.evenMinuteDateAfterNow(clock)
+                        .toInstant());
+    }
+
+    /*
+     * evenMinuteDate tests
+     */
+
+    @Test
+    void testEvenMinuteDate() {
+        assertEquals(
+                Instant.parse("2007-12-03T08:14:00.000Z"),
+                DateBuilder.evenMinuteDate(Date.from(Instant.parse("2007-12-03T08:13:54.341Z"))).toInstant());
+    }
+
+    @Test
+    void testEvenMinuteDateWithoutProvidedDateCurrentDateRoundedToSeconds() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        assertEquals(
+                Instant.parse("2007-12-03T08:14:00.000Z"),
+                DateBuilder.evenMinuteDate(null, clock)
+                        .toInstant());
+    }
+
+    /*
+     * evenMinuteDateBefore tests
+     */
+
+    @Test
+    void testEvenMinuteDateBefore() {
+        assertEquals(
+                Instant.parse("2007-12-03T08:13:00.000Z"),
+                DateBuilder.evenMinuteDateBefore(Date.from(Instant.parse("2007-12-03T08:13:54.341Z"))).toInstant());
+    }
+
+    @Test
+    void testEvenMinuteDateBeforeWithoutProvidedDateCurrentDateRoundedToSeconds() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        assertEquals(
+                Instant.parse("2007-12-03T08:13:00.000Z"),
+                DateBuilder.evenMinuteDateBefore(null, clock)
+                        .toInstant());
+    }
+
+    /*
+     * evenSecondDateAfterNow tests
+     */
+
+    @Test
+    void testEvenSecondDateAfterNow() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        assertEquals(
+                Instant.parse("2007-12-03T08:13:55.000Z"),
+                DateBuilder.evenSecondDateAfterNow(clock)
+                        .toInstant());
+    }
+
+    @Test
+    void testEvenSecondDateAfterNowDSTForward() {
+        var clock = Clock.fixed(
+                ZonedDateTime.parse("2024-03-31T01:59:59.999+01:00")
+                        .toInstant(),
+                ZoneId.of("Europe/Vienna"));
+        var before = clock.instant();
+        var result = DateBuilder.evenSecondDateAfterNow(clock).toInstant();
+
+        assertAll("DSTChange+1H",
+                () -> assertEquals(ZonedDateTime.parse("2024-03-31T01:59:59.999+01:00").toInstant(), before),
+                () -> assertEquals(ZonedDateTime.parse("2024-03-31T01:00:00.000Z").toInstant(), result),
+                () -> assertEquals(ZonedDateTime.parse("2024-03-31T03:00:00.000+02:00").toInstant(), result));
+    }
+
+    @Test
+    void testEvenSecondDateAfterNowDSTBackward() {
+        var clock = Clock.fixed(
+                ZonedDateTime.parse("2024-10-27T02:59:59.999+02:00")
+                        .toInstant(),
+                ZoneId.of("Europe/Vienna"));
+        var before = clock.instant();
+        var result = DateBuilder.evenSecondDateAfterNow(clock).toInstant();
+
+        assertAll("DSTChange-1H",
+                () -> assertEquals(ZonedDateTime.parse("2024-10-27T02:59:59.999+02:00").toInstant(), before),
+                () -> assertEquals(ZonedDateTime.parse("2024-10-27T01:00:00.000Z").toInstant(), result),
+                () -> assertEquals(ZonedDateTime.parse("2024-10-27T02:00:00.000+01:00").toInstant(), result));
+    }
+
+    /*
+     * evenSecondDate tests
+     */
+
+    @Test
+    void testEvenSecondDate() {
+        assertEquals(
+                Instant.parse("2007-12-03T08:13:55.000Z"),
+                DateBuilder.evenSecondDate(Date.from(Instant.parse("2007-12-03T08:13:54.341Z"))).toInstant());
+    }
+
+    @Test
+    void testEvenSecondDateWithoutProvidedDateCurrentDateRoundedToSeconds() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        assertEquals(
+                Instant.parse("2007-12-03T08:13:55.000Z"),
+                DateBuilder.evenSecondDate(null, clock)
+                        .toInstant());
+    }
+
+    /*
+     * evenSecondDateBefore tests
+     */
+
+    @Test
+    void testEvenSecondDateBefore() {
+        assertEquals(
+                Instant.parse("2007-12-03T08:13:54.000Z"),
+                DateBuilder.evenSecondDateBefore(Date.from(Instant.parse("2007-12-03T08:13:54.341Z"))).toInstant());
+    }
+
+    @Test
+    void testEvenSecondDateBeforeWithoutProvidedDateCurrentDateRoundedToSeconds() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T08:13:54.341Z"), ZoneOffset.UTC);
+        assertEquals(
+                Instant.parse("2007-12-03T08:13:54.000Z"),
+                DateBuilder.evenSecondDateBefore(null, clock)
+                        .toInstant());
+    }
+
+    /*
+     * nextGivenMinuteDate tests
+     */
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, -1, 60, Integer.MAX_VALUE })
+    void testNextGivenMinuteDateWithInvalidSecondBaseShouldThrow(int minuteBase) {
+        assertThrows(IllegalArgumentException.class, () -> DateBuilder.nextGivenMinuteDate(null, minuteBase));
+    }
+
+    private static Stream<Arguments> nextGivenMinuteDateTestData() {
+        return Stream.of(
+                Arguments.of("2007-12-03T11:16:41.123Z", 20, "2007-12-03T11:20:00.000Z"),
+                Arguments.of("2007-12-03T11:36:41.123Z", 20, "2007-12-03T11:40:00.000Z"),
+                Arguments.of("2007-12-03T11:46:41.123Z", 20, "2007-12-03T12:00:00.000Z"),
+
+                Arguments.of("2007-12-03T11:26:41.123Z", 30, "2007-12-03T11:30:00.000Z"),
+                Arguments.of("2007-12-03T11:36:41.123Z", 30, "2007-12-03T12:00:00.000Z"),
+
+                Arguments.of("2007-12-03T11:16:41.123Z", 17, "2007-12-03T11:17:00.000Z"),
+                Arguments.of("2007-12-03T11:17:41.123Z", 17, "2007-12-03T11:34:00.000Z"),
+                Arguments.of("2007-12-03T11:52:41.123Z", 17, "2007-12-03T12:00:00.000Z"),
+
+                Arguments.of("2007-12-03T11:52:41.123Z", 5, "2007-12-03T11:55:00.000Z"),
+                Arguments.of("2007-12-03T11:57:41.123Z", 5, "2007-12-03T12:00:00.000Z"),
+
+                Arguments.of("2007-12-03T11:17:41.123Z", 0, "2007-12-03T12:00:00.000Z"),
+                Arguments.of("2007-12-03T11:17:41.123Z", 1, "2007-12-03T11:18:00.000Z"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nextGivenMinuteDateTestData")
+    void testNextGivenMinuteDate(String input, int minuteBase, String expected) {
+        var instant = Instant.parse(input);
+        var result = DateBuilder.nextGivenMinuteDate(instant != null ? Date.from(instant) : null, minuteBase);
+        assertEquals(Instant.parse(expected), result.toInstant());
+    }
+
+    @Test
+    void testNextGivenMinuteDateWithNullDateShouldReturnCurrentDateRoundedToBaseMinute() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T10:15:30.123Z"), ZoneOffset.UTC);
+        var result = DateBuilder.nextGivenMinuteDate(null, 0, clock);
+        assertEquals(Instant.parse("2007-12-03T11:00:00.000Z"), result.toInstant());
+    }
+
+    /*
+     * nextGivenSecondDate tests
+     */
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, -1, 60, Integer.MAX_VALUE })
+    void testNextGivenSecondDateWithInvalidSecondBaseShouldThrow(int secondBase) {
+        assertThrows(IllegalArgumentException.class, () -> DateBuilder.nextGivenSecondDate(null, secondBase));
+    }
+
+    private static Stream<Arguments> nextGivenSecondDateTestData() {
+        return Stream.of(
+                Arguments.of("2007-12-03T10:15:30.123Z", 0, "2007-12-03T10:16:00.000Z"),
+                Arguments.of("2007-12-03T10:15:30.123Z", 1, "2007-12-03T10:15:31.000Z"),
+                Arguments.of("2007-12-03T10:15:54.256Z", 13, "2007-12-03T10:16:00.000Z"),
+                Arguments.of("2007-12-03T10:15:30.256Z", 13, "2007-12-03T10:15:39.000Z"),
+                Arguments.of("2007-12-03T10:15:30.000Z", 59, "2007-12-03T10:15:59.000Z"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nextGivenSecondDateTestData")
+    void testNextGivenSecondDate(String input, int secondBase, String expected) {
+        var instant = Instant.parse(input);
+        var result = DateBuilder.nextGivenSecondDate(instant != null ? Date.from(instant) : null, secondBase);
+        assertEquals(Instant.parse(expected), result.toInstant());
+    }
+
+    @Test
+    void testNextGivenSecondDateWithNullDateShouldReturnCurrentDateRoundedToBaseSecond() {
+        var clock = Clock.fixed(Instant.parse("2007-12-03T10:15:30.123Z"), ZoneOffset.UTC);
+        var result = DateBuilder.nextGivenSecondDate(null, 0, clock);
+        assertEquals(Instant.parse("2007-12-03T10:16:00.000Z"), result.toInstant());
+    }
+
+    /*
+     * translateTime tests
+     */
+
+    @Test
+    void testTranslate() {
+
+        TimeZone tz1 = TimeZone.getTimeZone("GMT-2:00");
+        TimeZone tz2 = TimeZone.getTimeZone("GMT-4:00");
+
+        Calendar vc = Calendar.getInstance(tz1);
         vc.set(Calendar.YEAR, 2013);
         vc.set(Calendar.MONTH, Calendar.JUNE);
         vc.set(Calendar.DAY_OF_MONTH, 1);
@@ -60,22 +591,10 @@ class DateBuilderTest {
         vc.set(Calendar.SECOND, 12);
         vc.set(Calendar.MILLISECOND, 0);
 
-        bd = newDate().inYear(2013).inMonth(JUNE).onDay(1).atHourOfDay(10).atMinute(33).atSecond(12).inTimeZone(tz).inLocale(lz).build();
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
+        vc.setTime(translateTime(vc.getTime(), tz1, tz2));
+        assertEquals(12, vc.get(Calendar.HOUR_OF_DAY));
 
-        bd = newDateInLocale(lz).inYear(2013).inMonth(JUNE).onDay(1).atHourOfDay(10).atMinute(33).atSecond(12).inTimeZone(tz).build();
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
-
-        bd = newDateInTimezone(tz).inYear(2013).inMonth(JUNE).onDay(1).atHourOfDay(10).atMinute(33).atSecond(12).inLocale(lz).build();
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
-
-        bd = newDateInTimeZoneAndLocale(tz, lz).inYear(2013).inMonth(JUNE).onDay(1).atHourOfDay(10).atMinute(33).atSecond(12).build();
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
-    }
-
-    @Test
-    void testEvensBuilders() {
-        Calendar vc = Calendar.getInstance();
+        vc = Calendar.getInstance(tz2);
         vc.set(Calendar.YEAR, 2013);
         vc.set(Calendar.MONTH, Calendar.JUNE);
         vc.set(Calendar.DAY_OF_MONTH, 1);
@@ -84,83 +603,178 @@ class DateBuilderTest {
         vc.set(Calendar.SECOND, 12);
         vc.set(Calendar.MILLISECOND, 0);
 
-        Calendar rd = (Calendar) vc.clone();
-
-        Date bd = newDate().inYear(2013).inMonth(JUNE).onDay(1).atHourOfDay(10).atMinute(33).atSecond(12).build();
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
-
-        rd.set(Calendar.MILLISECOND, 13);
-        bd = evenSecondDateBefore(rd.getTime());
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
-
-        vc.set(Calendar.SECOND, 13);
-        rd.set(Calendar.MILLISECOND, 13);
-        bd = evenSecondDate(rd.getTime());
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
-
-        vc.set(Calendar.SECOND, 0);
-        vc.set(Calendar.MINUTE, 34);
-        rd.set(Calendar.SECOND, 13);
-        bd = evenMinuteDate(rd.getTime());
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
-
-        vc.set(Calendar.SECOND, 0);
-        vc.set(Calendar.MINUTE, 33);
-        rd.set(Calendar.SECOND, 13);
-        bd = evenMinuteDateBefore(rd.getTime());
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
-
-        vc.set(Calendar.SECOND, 0);
-        vc.set(Calendar.MINUTE, 0);
-        vc.set(Calendar.HOUR_OF_DAY, 11);
-        rd.set(Calendar.SECOND, 13);
-        bd = evenHourDate(rd.getTime());
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
-
-        vc.set(Calendar.SECOND, 0);
-        vc.set(Calendar.MINUTE, 0);
-        vc.set(Calendar.HOUR_OF_DAY, 10);
-        rd.set(Calendar.SECOND, 13);
-        bd = evenHourDateBefore(rd.getTime());
-        assertEquals(vc.getTime(), bd, "DateBuilder-produced date is not as expected.");
-
-        Date td = new Date();
-        bd = evenHourDateAfterNow();
-        vc.setTime(bd);
-        assertEquals(0, vc.get(Calendar.MINUTE), "DateBuilder-produced date is not as expected.");
-        assertEquals(0, vc.get(Calendar.SECOND), "DateBuilder-produced date is not as expected.");
-        assertEquals(0, vc.get(Calendar.MILLISECOND), "DateBuilder-produced date is not as expected.");
-        assertTrue(bd.after(td), "DateBuilder-produced date is not as expected.");
-
-        vc.set(Calendar.SECOND, 54);
-        vc.set(Calendar.MINUTE, 13);
-        vc.set(Calendar.HOUR_OF_DAY, 8);
-        bd = nextGivenMinuteDate(vc.getTime(), 15);
-        vc.setTime(bd);
-        assertEquals(8, vc.get(Calendar.HOUR_OF_DAY), "DateBuilder-produced date is not as expected.");
-        assertEquals(15, vc.get(Calendar.MINUTE), "DateBuilder-produced date is not as expected.");
-        assertEquals(0, vc.get(Calendar.SECOND), "DateBuilder-produced date is not as expected.");
-        assertEquals(0, vc.get(Calendar.MILLISECOND), "DateBuilder-produced date is not as expected.");
+        vc.setTime(translateTime(vc.getTime(), tz2, tz1));
+        assertEquals(8, vc.get(Calendar.HOUR_OF_DAY));
     }
 
-    @Test
-    void testGivenBuilders() {
-        Calendar vc = Calendar.getInstance();
-
-        vc.set(Calendar.SECOND, 54);
-        vc.set(Calendar.MINUTE, 13);
-        vc.set(Calendar.HOUR_OF_DAY, 8);
-        Date bd = nextGivenMinuteDate(vc.getTime(), 45);
-        vc.setTime(bd);
-        assertEquals(8, vc.get(Calendar.HOUR_OF_DAY), "DateBuilder-produced date is not as expected.");
-        assertEquals(45, vc.get(Calendar.MINUTE), "DateBuilder-produced date is not as expected.");
-        assertEquals(0, vc.get(Calendar.SECOND), "DateBuilder-produced date is not as expected.");
-        assertEquals(0, vc.get(Calendar.MILLISECOND), "DateBuilder-produced date is not as expected.");
-
-        vc.set(Calendar.SECOND, 54);
-        vc.set(Calendar.MINUTE, 46);
-        vc.set(Calendar.HOUR_OF_DAY, 8);
-        bd = nextGivenMinuteDate(vc.getTime(), 45);
-        vc.setTime(bd);
+    private static Stream<Arguments> translateTimeTestData() {
+        return Stream.of(
+                Arguments.of(
+                        "2013-06-01T10:33:12-02:00",
+                        TimeZone.getTimeZone("GMT-2:00"),
+                        TimeZone.getTimeZone("GMT-4:00"),
+                        "2013-06-01T12:33:12-02:00"),
+                Arguments.of(
+                        "2013-06-01T10:33:12-04:00",
+                        TimeZone.getTimeZone("GMT-4:00"),
+                        TimeZone.getTimeZone("GMT-2:00"),
+                        "2013-06-01T08:33:12-04:00"));
     }
+
+    @ParameterizedTest
+    @MethodSource("translateTimeTestData")
+    void testTranslateTime(String input, TimeZone tzFrom, TimeZone tzTo, String expected) {
+        var zdt = ZonedDateTime.parse(input).withZoneSameInstant(tzFrom.toZoneId());
+        var result1 = translateTime(Date.from(zdt.toInstant()), tzFrom, tzTo);
+        assertEquals(ZonedDateTime.parse(expected).toInstant(), result1.toInstant());
+    }
+
+    /*
+     * validateDayOfWeek tests
+     */
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, -1, 0, 8, Integer.MAX_VALUE })
+    void testValidateDayOfWeekWithInvalidValueShouldThrow(int dayOfWeek) {
+        assertThrows(IllegalArgumentException.class, () -> DateBuilder.validateDayOfWeek(dayOfWeek));
+    }
+
+    private static Stream<Arguments> validateDayOfWeekTestData() {
+        return Stream.iterate(1, i -> i + 1)
+                .limit(7)
+                .map(i -> Arguments.of(i));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validateDayOfWeekTestData")
+    void testValidateDayOfWeek(int second) {
+        assertDoesNotThrow(() -> DateBuilder.validateDayOfWeek(second));
+    }
+
+    /*
+     * validateHour tests
+     */
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, -1, 24, Integer.MAX_VALUE })
+    void testValidateHourWithInvalidValueShouldThrow(int minute) {
+        assertThrows(IllegalArgumentException.class, () -> DateBuilder.validateHour(minute));
+    }
+
+    private static Stream<Arguments> validateHourTestData() {
+        return Stream.iterate(0, i -> i + 1)
+                .limit(24)
+                .map(i -> Arguments.of(i));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validateHourTestData")
+    void testValidateHour(int hour) {
+        assertDoesNotThrow(() -> DateBuilder.validateHour(hour));
+    }
+
+    /*
+     * validateMinutes tests
+     */
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, -1, 60, Integer.MAX_VALUE })
+    void testValidateMinuteWithInvalidValueShouldThrow(int minute) {
+        assertThrows(IllegalArgumentException.class, () -> DateBuilder.validateMinute(minute));
+    }
+
+    private static Stream<Arguments> validateMinuteTestData() {
+        return Stream.iterate(0, i -> i + 1)
+                .limit(60)
+                .map(i -> Arguments.of(i));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validateMinuteTestData")
+    void testValidateMinute(int minute) {
+        assertDoesNotThrow(() -> DateBuilder.validateMinute(minute));
+    }
+
+    /*
+     * validateSeconds tests
+     */
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, -1, 60, Integer.MAX_VALUE })
+    void testValidateSecondWithInvalidValueShouldThrow(int second) {
+        assertThrows(IllegalArgumentException.class, () -> DateBuilder.validateSecond(second));
+    }
+
+    private static Stream<Arguments> validateSecondsTestData() {
+        return Stream.iterate(0, i -> i + 1)
+                .limit(60)
+                .map(i -> Arguments.of(i));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validateSecondsTestData")
+    void testValidateSeconds(int second) {
+        assertDoesNotThrow(() -> DateBuilder.validateSecond(second));
+    }
+
+    /*
+     * validateDayOfMonth tests
+     */
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, -1, 0, 32, Integer.MAX_VALUE })
+    void testValidateDayOfMonthWithInvalidValueShouldThrow(int dayOfMonth) {
+        assertThrows(IllegalArgumentException.class, () -> DateBuilder.validateDayOfMonth(dayOfMonth));
+    }
+
+    private static Stream<Arguments> validateDayOfMonthTestData() {
+        return Stream.iterate(1, i -> i + 1)
+                .limit(31)
+                .map(i -> Arguments.of(i));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validateDayOfMonthTestData")
+    void testValidateDayOfMonth(int dayOfMonth) {
+        assertDoesNotThrow(() -> DateBuilder.validateDayOfMonth(dayOfMonth));
+    }
+
+    /*
+     * validateMonth tests
+     */
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, -1, 0, 13, Integer.MAX_VALUE })
+    void testValidateMonthWithInvalidValueShouldThrow(int month) {
+        assertThrows(IllegalArgumentException.class, () -> DateBuilder.validateMonth(month));
+    }
+
+    private static Stream<Arguments> validateMonthTestData() {
+        return Stream.iterate(1, i -> i + 1)
+                .limit(12)
+                .map(i -> Arguments.of(i));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validateMonthTestData")
+    void testValidateMonth(int month) {
+        assertDoesNotThrow(() -> DateBuilder.validateMonth(month));
+    }
+
+    /*
+     * validateYear tests
+     */
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, 1969, 1_000_000_000, Integer.MAX_VALUE })
+    void testValidateYearWithInvalidValueShouldThrow(int year) {
+        assertThrows(IllegalArgumentException.class, () -> DateBuilder.validateYear(year));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1970, 2024, 999_999_999 })
+    void testValidateYear(int year) {
+        assertDoesNotThrow(() -> DateBuilder.validateYear(year));
+    }
+
 }


### PR DESCRIPTION
## Changes
- made tests repeatable by injecting fixed Clock, instead of using current time
- adjusted some javadocs @param order to match method parameter order
- changed year validation to match javadoc i.e min value 1970 and set to max value to max that is supported by java

-----------------
## Checklist
- [x ] tested locally
- [ ] updated the docs
- [x] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

