### PR TITLE
Fix setRepeatInterval accepts invalid value

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/triggers/DailyTimeIntervalTriggerImpl.java
+++ b/quartz/src/main/java/org/quartz/impl/triggers/DailyTimeIntervalTriggerImpl.java
@@ -389,7 +389,7 @@ public class DailyTimeIntervalTriggerImpl extends AbstractTrigger<DailyTimeInter
      *              if repeatInterval is &lt; 1
      */
     public void setRepeatInterval( int repeatInterval) {
-        if (repeatInterval < 0) {
+        if (repeatInterval < 1) {
             throw new IllegalArgumentException(
                     "Repeat interval must be >= 1");
         }

--- a/quartz/src/test/java/org/quartz/impl/triggers/DailyTimeIntervalTriggerImplTest.java
+++ b/quartz/src/test/java/org/quartz/impl/triggers/DailyTimeIntervalTriggerImplTest.java
@@ -28,6 +28,8 @@ import java.util.Set;
 
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.quartz.DailyTimeIntervalScheduleBuilder;
 import org.quartz.DailyTimeIntervalTrigger;
 import org.quartz.DateBuilder;
@@ -623,7 +625,7 @@ class DailyTimeIntervalTriggerImplTest  {
         assertEquals("jobName", trigger.getJobName());
         assertEquals("jobGroup", trigger.getJobGroup());
         assertEquals(dateOf(8, 0, 0, 1, 1, 2012), trigger.getStartTime());
-      assertNull(trigger.getEndTime());
+        assertNull(trigger.getEndTime());
         assertEquals(new TimeOfDay(8, 0, 0), trigger.getStartTimeOfDay());
         assertEquals(new TimeOfDay(17, 0, 0), trigger.getEndTimeOfDay());
         assertEquals(IntervalUnit.HOUR, trigger.getRepeatIntervalUnit());
@@ -637,13 +639,20 @@ class DailyTimeIntervalTriggerImplTest  {
 
         assertEquals("triggerName", trigger.getName());
         assertEquals("triggerGroup", trigger.getGroup());
-      assertNull(trigger.getJobName());
+        assertNull(trigger.getJobName());
         assertEquals("DEFAULT", trigger.getJobGroup());
         assertEquals(dateOf(8, 0, 0, 1, 1, 2012), trigger.getStartTime());
-      assertNull(trigger.getEndTime());
+        assertNull(trigger.getEndTime());
         assertEquals(new TimeOfDay(8, 0, 0), trigger.getStartTimeOfDay());
         assertEquals(new TimeOfDay(17, 0, 0), trigger.getEndTimeOfDay());
         assertEquals(IntervalUnit.HOUR, trigger.getRepeatIntervalUnit());
         assertEquals(1, trigger.getRepeatInterval());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, 0})
+    void testSetRepeatIntervalWithInvalidValues(int repeatInterval) {
+        DailyTimeIntervalTriggerImpl trigger = new DailyTimeIntervalTriggerImpl();
+        assertThrows(IllegalArgumentException.class, () -> trigger.setRepeatInterval(repeatInterval));
     }
 }


### PR DESCRIPTION
Fixes setRepeatInterval accepts invalid value

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [x] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

