### PR TITLE
Add missing quartz.properties file for example5

### DIFF
--- a/examples/src/main/java/org/quartz/examples/example5/MisfireExample.java
+++ b/examples/src/main/java/org/quartz/examples/example5/MisfireExample.java
@@ -59,7 +59,7 @@ public class MisfireExample {
     log.info("------- Initializing -------------------");
 
     // First we must get a reference to a scheduler
-    SchedulerFactory sf = new StdSchedulerFactory();
+    SchedulerFactory sf = new StdSchedulerFactory("org/quartz/examples/example5/quartz_misfire.properties");
     Scheduler sched = sf.getScheduler();
 
     log.info("------- Initialization Complete -----------");

--- a/examples/src/main/resources/org/quartz/examples/example5/quartz_misfire.properties
+++ b/examples/src/main/resources/org/quartz/examples/example5/quartz_misfire.properties
@@ -1,0 +1,8 @@
+org.quartz.scheduler.instanceName: MisfireExampleScheduler
+
+org.quartz.threadPool.threadCount: 2
+org.quartz.threadPool.class: org.quartz.simpl.SimpleThreadPool
+
+# Set misfire threshold to 1 second
+org.quartz.jobStore.misfireThreshold: 1000
+org.quartz.jobStore.class: org.quartz.simpl.RAMJobStore


### PR DESCRIPTION
<!--
If this is your first time contributing to the project (or it's been a while), please consider reviewing https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
-->


This PR adds `quartz.properties` file for example5. The current version of the example5 doesn't showcase handling of misfires. This PR fixes that.

Fixes issue # 
example5 output

## Changes
- Adds `quartz.properties` file for example5

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

