### PR TITLE
[Feat] TriggerBuilder: TriggerBuilder's startAt Method Settings Type Extension

### DIFF
--- a/quartz/src/main/java/org/quartz/TriggerBuilder.java
+++ b/quartz/src/main/java/org/quartz/TriggerBuilder.java
@@ -18,6 +18,9 @@
 
 package org.quartz;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
 
 import org.quartz.spi.MutableTrigger;
@@ -223,6 +226,35 @@ public class TriggerBuilder<T extends Trigger> {
      */
     public TriggerBuilder<T> startAt(Date triggerStartTime) {
         this.startTime = triggerStartTime;
+        return this;
+    }
+
+
+    /**
+     * Change the LocalDateTime type to Date type to set the trigger start at.
+     * The ID of the Time Zone you want to set must also be delivered.
+     *
+     * @param triggerStartTime the start time for the Trigger but type is LocalDateTime
+     * @param triggerZoneId The time zone ID you want to set
+     * @return the updated TriggerBuilder
+     * @see Trigger#getStartTime()
+     * @see DateBuilder
+     */
+    public TriggerBuilder<T> startAt(LocalDateTime triggerStartTime, ZoneId triggerZoneId){
+        this.startTime = Date.from(triggerStartTime.atZone(triggerZoneId).toInstant());
+        return this;
+    }
+
+    /**
+     * Change the ZonedDateTime type to Date type to set the trigger start at.
+     *
+     * @param triggerStartTime the start time for the Trigger but type is ZonedDateTime
+     * @return the updated TriggerBuilder
+     * @see Trigger#getStartTime()
+     * @see DateBuilder
+     */
+    public TriggerBuilder<T> startAt(ZonedDateTime triggerStartTime){
+        this.startTime = Date.from(triggerStartTime.toInstant());
         return this;
     }
     

--- a/quartz/src/test/java/org/quartz/TriggerBuilderTest.java
+++ b/quartz/src/test/java/org/quartz/TriggerBuilderTest.java
@@ -21,6 +21,9 @@ import static org.quartz.DateBuilder.evenSecondDateAfterNow;
 import static org.quartz.DateBuilder.futureDate;
 import static org.quartz.TriggerBuilder.newTrigger;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
 
 
@@ -101,6 +104,32 @@ public class TriggerBuilderTest  {
                 .endAt(new Date(System.currentTimeMillis() - 100000000))
                 .withSchedule(CronScheduleBuilder.cronSchedule("0 0 0 * * ?"))
                 .build();
+    }
+
+    @Test
+    void testTriggerBuilderWithLocalDateTime() throws InterruptedException {
+        LocalDateTime localDateTime = LocalDateTime.now().plusSeconds(3);
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity("triggerTest LocalDateTime", "triggerTest LocalDateTime group")
+                .forJob("test job LocalDateTime", "test job LocalDateTime group")
+                .startAt(localDateTime, ZoneId.systemDefault())
+                .build();
+        assertEquals(Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant()), trigger.getStartTime());
+        Thread.sleep(5000);
+        assertEquals(Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant()), trigger.getFinalFireTime());
+    }
+
+    @Test
+    void testTriggerBuilderWithZonedDateTime() throws InterruptedException {
+        ZonedDateTime zonedDateTime = ZonedDateTime.now().plusSeconds(3);
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity("triggerTest ", "triggerTest LocalDateTime group")
+                .forJob("test job LocalDateTime", "test job LocalDateTime group")
+                .startAt(zonedDateTime)
+                .build();
+        assertEquals(Date.from(zonedDateTime.toInstant()),trigger.getStartTime());
+        Thread.sleep(5000);
+        assertEquals(Date.from(zonedDateTime.toInstant()),trigger.getFinalFireTime());
     }
 
 }


### PR DESCRIPTION
This PR extends the triggerBuilder's startAt type setting. Previously, only Date types could be delivered, so the user did the type conversion, but now LocalDateTime and ZonedDateTime can also be delivered without type conversion.

## Changes
= TriggerBuilder's startAt settings can be delivered to LocalDatetTime type
= TriggerBuilder's startAt settings can be delivered to ZonedDateTime type

## Checklist
- [x] tested locally
- [x] updated the docs
- [x] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via git commit -s on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners