### PR TITLE
Fix CVE-2019-13990 in quartz-2.1.x

### DIFF
--- a/quartz/src/main/java/org/quartz/xml/XMLSchedulingDataProcessor.java
+++ b/quartz/src/main/java/org/quartz/xml/XMLSchedulingDataProcessor.java
@@ -186,6 +186,13 @@ public class XMLSchedulingDataProcessor implements ErrorHandler {
         
         docBuilderFactory.setAttribute("http://java.sun.com/xml/jaxp/properties/schemaSource", resolveSchemaSource());
         
+        docBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        docBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        docBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        docBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        docBuilderFactory.setXIncludeAware(false);
+        docBuilderFactory.setExpandEntityReferences(false);
+        
         docBuilder = docBuilderFactory.newDocumentBuilder();
         
         docBuilder.setErrorHandler(this);

--- a/quartz/src/test/java/org/quartz/xml/XMLSchedulingDataProcessorTest.java
+++ b/quartz/src/test/java/org/quartz/xml/XMLSchedulingDataProcessorTest.java
@@ -29,6 +29,7 @@ import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.jobs.NoOpJob;
 import org.quartz.simpl.CascadingClassLoadHelper;
 import org.quartz.spi.ClassLoadHelper;
+import org.xml.sax.SAXParseException;
 
 /**
  * Unit test for XMLSchedulingDataProcessor.
@@ -109,6 +110,31 @@ public class XMLSchedulingDataProcessorTest extends TestCase {
 				outStream.close();
 			if (inStream != null)
 				inStream.close();
+		}
+	}
+
+	public void testXmlParserConfiguration() throws Exception {
+		Scheduler scheduler = null;
+		try {
+		  StdSchedulerFactory factory = new StdSchedulerFactory("org/quartz/xml/quartz-test.properties");
+		  scheduler = factory.getScheduler();
+		  ClassLoadHelper clhelper = new CascadingClassLoadHelper();
+		  clhelper.initialize();
+		  XMLSchedulingDataProcessor processor = new XMLSchedulingDataProcessor(clhelper);
+		  processor.processFileAndScheduleJobs("org/quartz/xml/bad-job-config.xml", scheduler);
+	
+	
+		  final JobKey jobKey = scheduler.getJobKeys(GroupMatcher.jobGroupEquals("native")).iterator().next();
+		  final JobDetail jobDetail = scheduler.getJobDetail(jobKey);
+		  final String description = jobDetail.getDescription();
+	
+	
+		  fail("Expected parser configuration to block DOCTYPE. The following was injected into the job description field: " + description);
+		} catch (SAXParseException e) {
+		  assertTrue(e.getMessage().contains("DOCTYPE is disallowed"));
+		} finally {
+		  if (scheduler != null)
+			scheduler.shutdown();
 		}
 	}
 	

--- a/quartz/src/test/resources/org/quartz/xml/bad-job-config.xml
+++ b/quartz/src/test/resources/org/quartz/xml/bad-job-config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE foo [<!ELEMENT foo ANY >
+		<!ENTITY xxe SYSTEM "/" >]>
+<job-scheduling-data xmlns="http://www.quartz-scheduler.org/xml/JobSchedulingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.quartz-scheduler.org/xml/JobSchedulingData http://www.quartz-scheduler.org/xml/job_scheduling_data_2_0.xsd" version="2.0">
+	<schedule>
+		<job>
+			<name>xxe</name>
+			<group>native</group>
+			<description>&xxe;</description>
+			<job-class>org.quartz.xml.XMLSchedulingDataProcessorTest$MyJob</job-class>
+			<durability>true</durability>
+			<recover>false</recover>
+		</job>
+	</schedule>
+</job-scheduling-data>


### PR DESCRIPTION
This is to fix vulnerability CVE-2019-13990 present in version 2.1.7.

The patch is identical to the fix provided for version 2.3.2 with fix commit [a1395ba](https://github.com/quartz-scheduler/quartz/commit/a1395ba118df306c7fe67c24fb0c9a95a4473140).

It has been tested through the down-ported unit test included in the same commit.

Disclaimer and background:
- It is clear that the given version is EOL, i.e. the project may not release a new version containing the patch, and the project generally advises users to migrate to later, supported versions. However, this fix could be a temporary remedy for users struggling to perform this migration (whatever the reason).
- This fix is part of [Endor Labs](https://www.endorlabs.com/)' efforts to create minimal invasive, yet viable security fixes for older OSS versions, similar to the well-known and established approach followed by various Linux distributions.
- By sharing the patch with the project community, we also hope to receive input as to whether the proposal is viable. It is clear, however, that the time of open source maintainers is limited. Hence, we appreciate any feedback given, but also understand if you cannot find the time to comment on merge requests opened for EOL versions.
-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [x] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

