### PR TITLE
Update dependency scope for DB backends

### DIFF
--- a/quartz/build.gradle
+++ b/quartz/build.gradle
@@ -19,8 +19,8 @@ dependencies {
 
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
     runtimeOnly "org.slf4j:slf4j-log4j12:$slf4jVersion"
-    implementation "com.mchange:c3p0:$c3p0Version"
-    implementation "com.zaxxer:HikariCP:$hikaricpVersion"
+    api "com.mchange:c3p0:$c3p0Version"
+    api "com.zaxxer:HikariCP:$hikaricpVersion"
     compileOnly "jboss:jboss-common:$jbossVersion"
     compileOnly "jboss:jboss-minimal:$jbossVersion"
     compileOnly "jboss:jboss-system:$jbossVersion"


### PR DESCRIPTION
When upgrading a project from Quartz 2.3.2 to 2.5.0 we ran into the following error:

```
Exception in thread "main" java.lang.NoClassDefFoundError: com/mchange/v2/c3p0/ComboPooledDataSource
	at org.quartz.utils.C3p0PoolingConnectionProvider.initialize(C3p0PoolingConnectionProvider.java:187)
	at org.quartz.utils.C3p0PoolingConnectionProvider.<init>(C3p0PoolingConnectionProvider.java:106)
	at com.rms.mapping.system.scheduler.QuartzSchedulerManager$.init(QuartzSchedulerManager.scala:225)
	at com.rms.mapping.system.scheduler.QuartzSchedulerManager$.apply(QuartzSchedulerManager.scala:201)
```

Looking at the Gradle build, it look like the `c3p0` dependency is declared as `implementation` which means it's not exposed on the runtime class path. While the workaround from #1310 is sufficient if these types are exposed in the library API then it seems to make sense to change their declaration scope.

 This PR updates the dependency declaration to restore the behavior of the 2.3.x library.

If these dependencies were intentionally hidden then perhaps a comment in the release notes or the README would be helpful?


<!--
If this is your first time contributing to the project (or it's been a while), please consider reviewing https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
-->


This PR...

Fixes issue #

## Changes
-

-----------------
## Checklist
- [ ] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [ ] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

