### PR TITLE
Fix incorrect error message

### DIFF
--- a/quartz/src/main/java/org/quartz/CronExpression.java
+++ b/quartz/src/main/java/org/quartz/CronExpression.java
@@ -721,15 +721,15 @@ public final class CronExpression implements Serializable, Cloneable {
 
     private void checkIncrementRange(int incr, int type, int idxPos) throws ParseException {
         if (incr > 59 && (type == SECOND || type == MINUTE)) {
-            throw new ParseException("Increment > 60 : " + incr, idxPos);
+            throw new ParseException("Increment >= 60 : " + incr, idxPos);
         } else if (incr > 23 && (type == HOUR)) {
-            throw new ParseException("Increment > 24 : " + incr, idxPos);
+            throw new ParseException("Increment >= 24 : " + incr, idxPos);
         } else if (incr > 31 && (type == DAY_OF_MONTH)) {
-            throw new ParseException("Increment > 31 : " + incr, idxPos);
+            throw new ParseException("Increment >= 31 : " + incr, idxPos);
         } else if (incr > 7 && (type == DAY_OF_WEEK)) {
-            throw new ParseException("Increment > 7 : " + incr, idxPos);
+            throw new ParseException("Increment >= 7 : " + incr, idxPos);
         } else if (incr > 12 && (type == MONTH)) {
-            throw new ParseException("Increment > 12 : " + incr, idxPos);
+            throw new ParseException("Increment >= 12 : " + incr, idxPos);
         }
     }
 

--- a/quartz/src/test/java/org/quartz/CronExpressionTest.java
+++ b/quartz/src/test/java/org/quartz/CronExpressionTest.java
@@ -318,7 +318,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("/120 0 8-18 ? * 2-6");
             fail("Cron did not validate bad range interval in '_blank/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 60 : 120", e.getMessage());
+            assertEquals("Increment >= 60 : 120", e.getMessage());
         }
 
         // Test case 2
@@ -326,7 +326,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("0/120 0 8-18 ? * 2-6");
             fail("Cron did not validate bad range interval in in '0/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 60 : 120", e.getMessage());
+            assertEquals("Increment >= 60 : 120", e.getMessage());
         }
 
         // Test case 3
@@ -344,6 +344,14 @@ public class CronExpressionTest extends SerializationTestSupport {
         } catch (ParseException e) {
             assertEquals("'/' must be followed by an integer.", e.getMessage());
         }
+
+        // Test case 5
+        try {
+            new CronExpression("/60 0 8-18 ? * 2-6");
+            fail("Cron did not validate bad range interval in '_blank/xxx' form");
+        } catch (ParseException e) {
+            assertEquals("Increment >= 60 : 60", e.getMessage());
+        }
     }
 
 
@@ -355,7 +363,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("0 /120 8-18 ? * 2-6");
             fail("Cron did not validate bad range interval in '_blank/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 60 : 120", e.getMessage());
+            assertEquals("Increment >= 60 : 120", e.getMessage());
         }
 
         // Test case 2
@@ -363,7 +371,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("0 0/120 8-18 ? * 2-6");
             fail("Cron did not validate bad range interval in in '0/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 60 : 120", e.getMessage());
+            assertEquals("Increment >= 60 : 120", e.getMessage());
         }
 
         // Test case 3
@@ -381,6 +389,14 @@ public class CronExpressionTest extends SerializationTestSupport {
         } catch (ParseException e) {
             assertEquals("'/' must be followed by an integer.", e.getMessage());
         }
+
+        // Test case 5
+        try {
+            new CronExpression("0 /60 8-18 ? * 2-6");
+            fail("Cron did not validate bad range interval in '_blank/xxx' form");
+        } catch (ParseException e) {
+            assertEquals("Increment >= 60 : 60", e.getMessage());
+        }
     }
 
     // Issue #58
@@ -391,7 +407,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("0 0 /120 ? * 2-6");
             fail("Cron did not validate bad range interval in '_blank/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 24 : 120", e.getMessage());
+            assertEquals("Increment >= 24 : 120", e.getMessage());
         }
 
         // Test case 2
@@ -399,7 +415,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("0 0 0/120 ? * 2-6");
             fail("Cron did not validate bad range interval in in '0/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 24 : 120", e.getMessage());
+            assertEquals("Increment >= 24 : 120", e.getMessage());
         }
 
         // Test case 3
@@ -417,6 +433,14 @@ public class CronExpressionTest extends SerializationTestSupport {
         } catch (ParseException e) {
             assertEquals("'/' must be followed by an integer.", e.getMessage());
         }
+
+        // Test case 5
+        try {
+            new CronExpression("0 0 /24 ? * 2-6");
+            fail("Cron did not validate bad range interval in '_blank/xxx' form");
+        } catch (ParseException e) {
+            assertEquals("Increment >= 24 : 24", e.getMessage());
+        }
     }
 
     // Issue #58
@@ -427,7 +451,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("0 0 0 /120 * 2-6");
             fail("Cron did not validate bad range interval in '_blank/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 31 : 120", e.getMessage());
+            assertEquals("Increment >= 31 : 120", e.getMessage());
         }
 
         // Test case 2
@@ -435,7 +459,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("0 0 0 0/120 * 2-6");
             fail("Cron did not validate bad range interval in in '0/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 31 : 120", e.getMessage());
+            assertEquals("Increment >= 31 : 120", e.getMessage());
         }
 
         // Test case 3
@@ -463,7 +487,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("0 0 0 ? /120 2-6");
             fail("Cron did not validate bad range interval in '_blank/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 12 : 120", e.getMessage());
+            assertEquals("Increment >= 12 : 120", e.getMessage());
         }
 
         // Test case 2
@@ -471,7 +495,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("0 0 0 ? 0/120 2-6");
             fail("Cron did not validate bad range interval in in '0/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 12 : 120", e.getMessage());
+            assertEquals("Increment >= 12 : 120", e.getMessage());
         }
 
         // Test case 3
@@ -489,6 +513,14 @@ public class CronExpressionTest extends SerializationTestSupport {
         } catch (ParseException e) {
             assertEquals("'/' must be followed by an integer.", e.getMessage());
         }
+
+        // Test case 5
+        try {
+            new CronExpression("0 0 0 ? /13 2-6");
+            fail("Cron did not validate bad range interval in '_blank/xxx' form");
+        } catch (ParseException e) {
+            assertEquals("Increment >= 12 : 13", e.getMessage());
+        }
     }
 
 
@@ -501,7 +533,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("0 0 0 ? * /120");
             fail("Cron did not validate bad range interval in '_blank/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 7 : 120", e.getMessage());
+            assertEquals("Increment >= 7 : 120", e.getMessage());
         }
 
         // Test case 2
@@ -509,7 +541,7 @@ public class CronExpressionTest extends SerializationTestSupport {
             new CronExpression("0 0 0 ? * 0/120");
             fail("Cron did not validate bad range interval in in '0/xxx' form");
         } catch (ParseException e) {
-            assertEquals("Increment > 7 : 120", e.getMessage());
+            assertEquals("Increment >= 7 : 120", e.getMessage());
         }
 
         // Test case 3


### PR DESCRIPTION
Error message on parsing increment range is incorrect: border values (60 for minutes and seconds, 24 for hours and so on) are also not allowed.