### PR TITLE
close ByteArrayInputStream in PostgreSQLDelegate

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PostgreSQLDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PostgreSQLDelegate.java
@@ -58,21 +58,15 @@ public class PostgreSQLDelegate extends StdJDBCDelegate {
     @Override           
     protected Object getObjectFromBlob(ResultSet rs, String colName)
         throws ClassNotFoundException, IOException, SQLException {
-        InputStream binaryInput;
         byte[] bytes = rs.getBytes(colName);
-        
-        Object obj = null;
-        
-        if(bytes != null && bytes.length != 0) {
-            binaryInput = new ByteArrayInputStream(bytes);
-
-            try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-                obj = in.readObject();
-            }
-
+        if (bytes == null || bytes.length == 0) {
+            return null;
         }
-        
-        return obj;
+
+        try (ObjectInputStream in = new ObjectInputStream(
+                new ByteArrayInputStream(bytes))) {
+            return in.readObject();
+        }
     }
 
     @Override           


### PR DESCRIPTION
<!--
If this is your first time contributing to the project (or it's been a while), please consider reviewing https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
-->


close ByteArrayInputStream in PostgreSQLDelegate

Fixes issue #

## Changes
-

-----------------
## Checklist
- [ ] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [ ] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

