### PR TITLE
fix #1297 , NPE when IntervalUnit is Millisecond

### DIFF
--- a/quartz/src/main/java/org/quartz/CalendarIntervalScheduleBuilder.java
+++ b/quartz/src/main/java/org/quartz/CalendarIntervalScheduleBuilder.java
@@ -104,14 +104,18 @@ public class CalendarIntervalScheduleBuilder extends ScheduleBuilder<CalendarInt
      * Specify the time unit and interval for the Trigger to be produced.
      * 
      * @param timeInterval the interval at which the trigger should repeat.
-     * @param unit  the time unit (IntervalUnit) of the interval.
+     * @param unit  the time unit (IntervalUnit) of the interval.  Cannot be less than IntervalUnit.SECOND .
      * @return the updated CalendarIntervalScheduleBuilder
      * @see CalendarIntervalTrigger#getRepeatInterval()
      * @see CalendarIntervalTrigger#getRepeatIntervalUnit()
+     * @throws IllegalArgumentException if unit is null or is IntervalUnit.MILLISECOND
      */
     public CalendarIntervalScheduleBuilder withInterval(int timeInterval, IntervalUnit unit) {
         if(unit == null)
             throw new IllegalArgumentException("TimeUnit must be specified.");
+        if(unit.equals(IntervalUnit.MILLISECOND))
+            throw new IllegalArgumentException("TimeUnit cannot be less than SECOND.");
+
         validateInterval(timeInterval);
         this.interval = timeInterval;
         this.intervalUnit = unit;


### PR DESCRIPTION
This PR...

Fixes issue #1297

-----------------
## Checklist
- [X] updated the docs
- [X] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

