### PR TITLE
Fix millisecond interval calculation for hourly triggers

### DIFF
--- a/quartz/src/main/java/org/quartz/DailyTimeIntervalScheduleBuilder.java
+++ b/quartz/src/main/java/org/quartz/DailyTimeIntervalScheduleBuilder.java
@@ -332,7 +332,7 @@ public class DailyTimeIntervalScheduleBuilder extends ScheduleBuilder<DailyTimeI
         else if (intervalUnit == IntervalUnit.MINUTE)
                 intervalInMillis = interval * 1000L * 60;
         else if (intervalUnit == IntervalUnit.HOUR)
-            intervalInMillis = interval * 1000L * 60 * 24;
+            intervalInMillis = interval * 1000L * 60 * 60;
         else
             throw new IllegalArgumentException("The IntervalUnit: " + intervalUnit + " is invalid for this trigger."); 
         


### PR DESCRIPTION


<!--
If this is your first time contributing to the project (or it's been a while), please consider reviewing https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
-->


Fix #1348 , #1427
There are 60*60 seconds in an hour

Fixes issue [#1348](https://github.com/quartz-scheduler/quartz/discussions/1348)

## Changes
- update milliseconds per houw calculation

-----------------
## Checklist
- [ ] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

