### PR TITLE
fix #1408, HSQLDBDelegate cannot read H2 file blobs

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/HSQLDBDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/HSQLDBDelegate.java
@@ -61,7 +61,7 @@ public class HSQLDBDelegate extends StdJDBCDelegate {
         throws ClassNotFoundException, IOException, SQLException {
         InputStream binaryInput = rs.getBinaryStream(colName);
 
-        if(binaryInput == null || binaryInput.available() == 0) {
+        if (binaryInput == null || (!binaryInput.getClass().getName().equals("org.h2.mvstore.db.LobStorageMap$LobInputStream") && binaryInput.available() == 0)) {
             return null;
         }
         


### PR DESCRIPTION
<!--
If this is your first time contributing to the project (or it's been a while), please consider reviewing https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md
-->


This PR allows Blobs stored in H2 file format to be read by the HSQLDBDelegate. 

Fix #1408

## Changes
- Checks whether a Blob is a LobInputStream before calling available(), as LobInputStream has available() return 0 even if there is content.

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs: **N/A**
- [ ] added appropriate test: **work in progress, but was suggested to create PR for code change first**
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

