### PR TITLE
Limit result set size while fetching misfires jobs

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
@@ -355,6 +355,8 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
             ps = conn.prepareStatement(rtp(SELECT_HAS_MISFIRED_TRIGGERS_IN_STATE));
             ps.setBigDecimal(1, new BigDecimal(String.valueOf(ts)));
             ps.setString(2, state1);
+            ps.setMaxRows(count + 1); // to determine if there are more beyond count
+            ps.setFetchSize(count + 1);
             rs = ps.executeQuery();
 
             boolean hasReachedLimit = false;


### PR DESCRIPTION
This PR limits the result dataset while fetching misfire jobs from the table by requested amount. 

Fixes issue #**NA**

## Changes
- Considering that `maxMisfiresToHandleAtATime` is 20 JDBC driver will load more records into the buffer than the actual limit and consumes more memory than it is really needed. 
- Another performance aspect is the query causes `filesort` due to `PRIORITY DESC` on MySQL which forces reads all eligible records from the table. The query runs under `TRIGGER_ACCESS` lock which affects the overall the library performance to process the jobs. By setting the limit MySQL will read only N records before doing `filesort` which reduces the query time significantly

-----------------
## Checklist
- [X] tested locally as well as under performance test (more 1 million of misfired jobs)
- [ ] updated the docs - **NA**
- [ ] added appropriate test - No tests are required
- [X] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

