### PR TITLE
Optimize removeTrigger method

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/DriverDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/DriverDelegate.java
@@ -607,6 +607,20 @@ public interface DriverDelegate {
 
     /**
      * <p>
+     * Check if there are more tiggers associated with a given job.
+     * </p>
+     *
+     * @param connection
+     * @param jobKey
+     * @return
+     * @throws SQLException
+     */
+     default boolean hasMoreTriggersForJob(Connection connection, JobKey jobKey) throws SQLException {
+        return selectNumTriggersForJob(connection, jobKey) > 0;
+     }
+
+    /**
+     * <p>
      * Select the job to which the trigger is associated.
      * </p>
      * 

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -1460,9 +1460,7 @@ public abstract class JobStoreSupport implements JobStore, Constants {
                 deleteTriggerAndChildren(conn, key);
 
             if (null != job && !job.isDurable()) {
-                int numTriggers = getDelegate().selectNumTriggersForJob(conn,
-                        job.getKey());
-                if (numTriggers == 0) {
+                if (!getDelegate().hasMoreTriggersForJob(conn, job.getKey())) {
                     // Don't call removeJob() because we don't want to check for
                     // triggers again.
                     deleteJobAndChildren(conn, job.getKey());

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCConstants.java
@@ -434,6 +434,11 @@ public interface StdJDBCConstants extends Constants {
             + " AND " + COL_JOB_NAME + " = ? AND "
             + COL_JOB_GROUP + " = ?";
 
+    String SELECT_TRIGGER_NAMES_FOR_JOB = "SELECT TRIGGER_NAME"
+            + " FROM " + TABLE_PREFIX_SUBST + TABLE_TRIGGERS
+            + " WHERE " + COL_SCHEDULER_NAME + " = " + SCHED_NAME_SUBST
+            + " AND " + COL_JOB_NAME + " = ? AND " + COL_JOB_GROUP + " = ?";
+
     String SELECT_JOB_FOR_TRIGGER = "SELECT J."
             + COL_JOB_NAME + ", J." + COL_JOB_GROUP + ", J." + COL_IS_DURABLE
             + ", J." + COL_JOB_CLASS + ", J." + COL_REQUESTS_RECOVERY + " FROM " + TABLE_PREFIX_SUBST

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
@@ -1617,6 +1617,39 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
 
     /**
      * <p>
+     * Check if there are more tiggers associated with a given job.
+     * </p>
+     *
+     * @param connection
+     * @param jobKey
+     * @return
+     * @throws SQLException
+     */
+    @Override
+    public boolean hasMoreTriggersForJob(Connection connection, JobKey jobKey) throws SQLException {
+      PreparedStatement ps = null;
+      ResultSet rs = null;
+      try {
+        ps = connection.prepareStatement(rtp(SELECT_TRIGGER_NAMES_FOR_JOB));
+        ps.setString(1, jobKey.getName());
+        ps.setString(2, jobKey.getGroup());
+        ps.setMaxRows(1);
+        ps.setFetchSize(1);
+        rs = ps.executeQuery();
+
+        int count = 0;
+        while (rs.next()) {
+          count ++;
+        }
+        return count > 0;
+      } finally {
+        closeResultSet(rs);
+        closeStatement(ps);
+      }
+  }
+
+  /**
+     * <p>
      * Select the job to which the trigger is associated.
      * </p>
      *


### PR DESCRIPTION
This PR optimizes `removeTrigger` method.

Fixes issue # **NA**

## Changes
- `removeTrigger` method checks if there are more tiggers associated with a job every time when a trigger is being removed. Although `SELECT COUNT` is technically correct it will be always slower and need more IO versus the proposed change. The change reduces amount of IO which is important on Cloud based DB (aka RDS) as well as improve the performance if a job has a few thousands of triggers 

-----------------
## Checklist
- [X] tested locally as well as under performance test using a real scenario
- [ ] updated the docs - NA
- [X] added appropriate test - the change is covered by existing Unit and Integration tests
- [X] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

