### PR TITLE
Fixing calculation of getFireTimeAfter in CalendarIntervalTriggerImpl

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
+++ b/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
@@ -19,6 +19,9 @@
 
 package org.quartz.impl.triggers;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
@@ -36,13 +39,12 @@ import org.quartz.SimpleTrigger;
 import org.quartz.Trigger;
 import org.quartz.TriggerUtils;
 
-
 /**
  * <p>A concrete <code>{@link Trigger}</code> that is used to fire a <code>{@link org.quartz.JobDetail}</code>
  * based upon repeating calendar time intervals.</p>
  * 
  * <p>The trigger will fire every N (see {@link #setRepeatInterval(int)} ) units of calendar time
- * (see {@link #setRepeatIntervalUnit(org.quartz.DateBuilder.IntervalUnit)}) as specified in the trigger's definition.
+ * (see {@link #setRepeatIntervalUnit(IntervalUnit)}) as specified in the trigger's definition.
  * This trigger can achieve schedules that are not possible with {@link SimpleTrigger} (e.g 
  * because months are not a fixed number of seconds) or {@link CronTrigger} (e.g. because
  * "every 5 months" is not an even divisor of 12).</p>
@@ -78,7 +80,7 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
     private static final long serialVersionUID = -2635982274232850343L;
 
     
-    private static final int YEAR_TO_GIVEUP_SCHEDULING_AT = java.util.Calendar.getInstance().get(java.util.Calendar.YEAR) + 100;
+    private static final int YEAR_TO_GIVEUP_SCHEDULING_AT = Calendar.getInstance().get(Calendar.YEAR) + 100;
 
     /*
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -521,9 +523,9 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
                 break;
             
             //avoid infinite loop
-            java.util.Calendar c = java.util.Calendar.getInstance();
+            Calendar c = Calendar.getInstance();
             c.setTime(nextFireTime);
-            if (c.get(java.util.Calendar.YEAR) > YEAR_TO_GIVEUP_SCHEDULING_AT) {
+            if (c.get(Calendar.YEAR) > YEAR_TO_GIVEUP_SCHEDULING_AT) {
                 nextFireTime = null;
             }
         }
@@ -552,9 +554,9 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
                 break;
             
             //avoid infinite loop
-            java.util.Calendar c = java.util.Calendar.getInstance();
+            Calendar c = Calendar.getInstance();
             c.setTime(nextFireTime);
-            if (c.get(java.util.Calendar.YEAR) > YEAR_TO_GIVEUP_SCHEDULING_AT) {
+            if (c.get(Calendar.YEAR) > YEAR_TO_GIVEUP_SCHEDULING_AT) {
                 nextFireTime = null;
             }
 
@@ -596,9 +598,9 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
                 break;
 
             //avoid infinite loop
-            java.util.Calendar c = java.util.Calendar.getInstance();
+            Calendar c = Calendar.getInstance();
             c.setTime(nextFireTime);
-            if (c.get(java.util.Calendar.YEAR) > YEAR_TO_GIVEUP_SCHEDULING_AT) {
+            if (c.get(Calendar.YEAR) > YEAR_TO_GIVEUP_SCHEDULING_AT) {
                 return null;
             }
         }
@@ -698,148 +700,69 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
             return new Date(startMillis);
         }
 
-        
-        long secondsAfterStart = 1 + (afterMillis - startMillis) / 1000L;
-
-        Date time = null;
-        long repeatLong = getRepeatInterval();
-        
         Calendar aTime = Calendar.getInstance();
         aTime.setTime(afterTime);
 
         Calendar sTime = Calendar.getInstance();
-        if(timeZone != null)
+        if(timeZone != null) {
             sTime.setTimeZone(timeZone);
+        }
         sTime.setTime(getStartTime());
         sTime.setLenient(true);
-        
-        if(getRepeatIntervalUnit().equals(IntervalUnit.SECOND)) {
-            long jumpCount = secondsAfterStart / repeatLong;
-            if(secondsAfterStart % repeatLong != 0)
-                jumpCount++;
-            sTime.add(Calendar.SECOND, getRepeatInterval() * (int)jumpCount);
-            time = sTime.getTime();
-        }
-        else if(getRepeatIntervalUnit().equals(IntervalUnit.MINUTE)) {
-            long jumpCount = secondsAfterStart / (repeatLong * 60L);
-            if(secondsAfterStart % (repeatLong * 60L) != 0)
-                jumpCount++;
-            sTime.add(Calendar.MINUTE, getRepeatInterval() * (int)jumpCount);
-            time = sTime.getTime();
-        }
-        else if(getRepeatIntervalUnit().equals(IntervalUnit.HOUR)) {
-            long jumpCount = secondsAfterStart / (repeatLong * 60L * 60L);
-            if(secondsAfterStart % (repeatLong * 60L * 60L) != 0)
-                jumpCount++;
-            sTime.add(Calendar.HOUR_OF_DAY, getRepeatInterval() * (int)jumpCount);
-            time = sTime.getTime();
-        }
-        else { // intervals a day or greater ...
 
-            int initialHourOfDay = sTime.get(Calendar.HOUR_OF_DAY);
-            
-            if(getRepeatIntervalUnit().equals(IntervalUnit.DAY)) {
-                sTime.setLenient(true);
-                
-                // Because intervals greater than an hour have an non-fixed number 
-                // of seconds in them (due to daylight savings, variation number of 
-                // days in each month, leap year, etc. ) we can't jump forward an
-                // exact number of seconds to calculate the fire time as we can
-                // with the second, minute and hour intervals.   But, rather
-                // than slowly crawling our way there by iteratively adding the 
-                // increment to the start time until we reach the "after time",
-                // we can first make a big leap most of the way there...
-                
-                long jumpCount = secondsAfterStart / (repeatLong * 24L * 60L * 60L);
-                // if we need to make a big jump, jump most of the way there, 
-                // but not all the way because in some cases we may over-shoot or under-shoot
-                if(jumpCount > 20) {
-                    if(jumpCount < 50)
-                        jumpCount = (long) (jumpCount * 0.80);
-                    else if(jumpCount < 500)
-                        jumpCount = (long) (jumpCount * 0.90);
-                    else
-                        jumpCount = (long) (jumpCount * 0.95);
-                    sTime.add(java.util.Calendar.DAY_OF_YEAR, (int) (getRepeatInterval() * jumpCount));
-                }
-                
-                // now baby-step the rest of the way there...
-                while(!sTime.getTime().after(afterTime) &&
-                        (sTime.get(java.util.Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {            
-                    sTime.add(java.util.Calendar.DAY_OF_YEAR, getRepeatInterval());
-                }
-                while(daylightSavingHourShiftOccurredAndAdvanceNeeded(sTime, initialHourOfDay, afterTime) &&
-                        (sTime.get(java.util.Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {
-                    sTime.add(java.util.Calendar.DAY_OF_YEAR, getRepeatInterval());
-                }
-                time = sTime.getTime();
+        ChronoUnit chronoUnit = switch (getRepeatIntervalUnit()) {
+            case MILLISECOND -> ChronoUnit.MILLIS;
+            case SECOND -> ChronoUnit.SECONDS;
+            case MINUTE -> ChronoUnit.MINUTES;
+            case HOUR -> ChronoUnit.HOURS;
+            case DAY -> ChronoUnit.DAYS;
+            case WEEK -> ChronoUnit.WEEKS;
+            case MONTH -> ChronoUnit.MONTHS;
+            case YEAR -> ChronoUnit.YEARS;
+        };
+        int calendarField = switch (getRepeatIntervalUnit()) {
+            case MILLISECOND -> Calendar.MILLISECOND;
+            case SECOND -> Calendar.SECOND;
+            case MINUTE -> Calendar.MINUTE;
+            case HOUR -> Calendar.HOUR_OF_DAY;
+            case DAY -> Calendar.DAY_OF_YEAR;
+            case WEEK -> Calendar.WEEK_OF_YEAR;
+            case MONTH -> Calendar.MONTH;
+            case YEAR -> Calendar.YEAR;
+        };
+
+        final long unitsSinceStart;
+        if(chronoUnit.compareTo(ChronoUnit.DAYS) > 0) {
+            ZoneId zoneId = sTime.getTimeZone().toZoneId();
+            LocalDateTime aDateTime = LocalDateTime.ofInstant(aTime.toInstant(), zoneId);
+            LocalDateTime sDateTime = LocalDateTime.ofInstant(sTime.toInstant(), zoneId);
+            unitsSinceStart = chronoUnit.between(aDateTime, sDateTime);
+        } else {
+            unitsSinceStart = chronoUnit.between(aTime.toInstant(), sTime.toInstant());
+        }
+        int intervalUnitsSinceStart = getRepeatInterval() * (int)(unitsSinceStart / getRepeatInterval());
+        int initialHourOfDay = -1;
+        if(chronoUnit.compareTo(ChronoUnit.DAYS) >= 0) {
+            initialHourOfDay = sTime.get(Calendar.HOUR_OF_DAY);
+        }
+        sTime.add(calendarField, intervalUnitsSinceStart);
+        while(!sTime.getTime().after(afterTime) &&
+            (sTime.get(Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {
+            sTime.setTime(getStartTime());
+            intervalUnitsSinceStart += getRepeatInterval();
+            sTime.add(calendarField, intervalUnitsSinceStart);
+        }
+        if(initialHourOfDay >= 0) {
+            while(daylightSavingHourShiftOccurredAndAdvanceNeeded(sTime, initialHourOfDay, afterTime) &&
+                    (sTime.get(Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {
+                sTime.setTime(getStartTime());
+                intervalUnitsSinceStart += getRepeatInterval();
+                sTime.add(calendarField, intervalUnitsSinceStart);
             }
-            else if(getRepeatIntervalUnit().equals(IntervalUnit.WEEK)) {
-                sTime.setLenient(true);
-    
-                // Because intervals greater than an hour have an non-fixed number 
-                // of seconds in them (due to daylight savings, variation number of 
-                // days in each month, leap year, etc. ) we can't jump forward an
-                // exact number of seconds to calculate the fire time as we can
-                // with the second, minute and hour intervals.   But, rather
-                // than slowly crawling our way there by iteratively adding the 
-                // increment to the start time until we reach the "after time",
-                // we can first make a big leap most of the way there...
-                
-                long jumpCount = secondsAfterStart / (repeatLong * 7L * 24L * 60L * 60L);
-                // if we need to make a big jump, jump most of the way there, 
-                // but not all the way because in some cases we may over-shoot or under-shoot
-                if(jumpCount > 20) {
-                    if(jumpCount < 50)
-                        jumpCount = (long) (jumpCount * 0.80);
-                    else if(jumpCount < 500)
-                        jumpCount = (long) (jumpCount * 0.90);
-                    else
-                        jumpCount = (long) (jumpCount * 0.95);
-                    sTime.add(java.util.Calendar.WEEK_OF_YEAR, (int) (getRepeatInterval() * jumpCount));
-                }
-                
-                while(!sTime.getTime().after(afterTime) &&
-                        (sTime.get(java.util.Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {            
-                    sTime.add(java.util.Calendar.WEEK_OF_YEAR, getRepeatInterval());
-                }
-                while(daylightSavingHourShiftOccurredAndAdvanceNeeded(sTime, initialHourOfDay, afterTime) &&
-                        (sTime.get(java.util.Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {
-                    sTime.add(java.util.Calendar.WEEK_OF_YEAR, getRepeatInterval());
-                }
-                time = sTime.getTime();
-            }
-            else if(getRepeatIntervalUnit().equals(IntervalUnit.MONTH)) {
-                sTime.setLenient(true);
-    
-                // because of the large variation in size of months, and 
-                // because months are already large blocks of time, we will
-                // just advance via brute-force iteration.
-                
-                while(!sTime.getTime().after(afterTime) &&
-                        (sTime.get(java.util.Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {            
-                    sTime.add(java.util.Calendar.MONTH, getRepeatInterval());
-                }
-                while(daylightSavingHourShiftOccurredAndAdvanceNeeded(sTime, initialHourOfDay, afterTime) &&
-                        (sTime.get(java.util.Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {
-                    sTime.add(java.util.Calendar.MONTH, getRepeatInterval());
-                }
-                time = sTime.getTime();
-            }
-            else if(getRepeatIntervalUnit().equals(IntervalUnit.YEAR)) {
-    
-                while(!sTime.getTime().after(afterTime) &&
-                        (sTime.get(java.util.Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {            
-                    sTime.add(java.util.Calendar.YEAR, getRepeatInterval());
-                }
-                while(daylightSavingHourShiftOccurredAndAdvanceNeeded(sTime, initialHourOfDay, afterTime) &&
-                        (sTime.get(java.util.Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {
-                    sTime.add(java.util.Calendar.YEAR, getRepeatInterval());
-                }
-                time = sTime.getTime();
-            }
-        } // case of interval of a day or greater
-        
+        }
+
+        Date time = sTime.getTime();
+
         if (!ignoreEndTime && (endMillis <= time.getTime())) {
             return null;
         }
@@ -891,28 +814,18 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
             lTime.setTimeZone(timeZone);
         lTime.setTime(fTime);
         lTime.setLenient(true);
-        
-        if(getRepeatIntervalUnit().equals(IntervalUnit.SECOND)) {
-            lTime.add(java.util.Calendar.SECOND, -1 * getRepeatInterval());
-        }
-        else if(getRepeatIntervalUnit().equals(IntervalUnit.MINUTE)) {
-            lTime.add(java.util.Calendar.MINUTE, -1 * getRepeatInterval());
-        }
-        else if(getRepeatIntervalUnit().equals(IntervalUnit.HOUR)) {
-            lTime.add(java.util.Calendar.HOUR_OF_DAY, -1 * getRepeatInterval());
-        }
-        else if(getRepeatIntervalUnit().equals(IntervalUnit.DAY)) {
-            lTime.add(java.util.Calendar.DAY_OF_YEAR, -1 * getRepeatInterval());
-        }
-        else if(getRepeatIntervalUnit().equals(IntervalUnit.WEEK)) {
-            lTime.add(java.util.Calendar.WEEK_OF_YEAR, -1 * getRepeatInterval());
-        }
-        else if(getRepeatIntervalUnit().equals(IntervalUnit.MONTH)) {
-            lTime.add(java.util.Calendar.MONTH, -1 * getRepeatInterval());
-        }
-        else if(getRepeatIntervalUnit().equals(IntervalUnit.YEAR)) {
-            lTime.add(java.util.Calendar.YEAR, -1 * getRepeatInterval());
-        }
+
+        int calendarField = switch (getRepeatIntervalUnit()) {
+            case MILLISECOND -> Calendar.MILLISECOND;
+            case SECOND -> Calendar.SECOND;
+            case MINUTE -> Calendar.MINUTE;
+            case HOUR -> Calendar.HOUR_OF_DAY;
+            case DAY -> Calendar.DAY_OF_YEAR;
+            case WEEK -> Calendar.WEEK_OF_YEAR;
+            case MONTH -> Calendar.MONTH;
+            case YEAR -> Calendar.YEAR;
+        };
+        lTime.add(calendarField, -1 * getRepeatInterval());
 
         return lTime.getTime();
     }

--- a/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
+++ b/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
@@ -710,26 +710,30 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
         sTime.setTime(getStartTime());
         sTime.setLenient(true);
 
-        ChronoUnit chronoUnit = switch (getRepeatIntervalUnit()) {
-            case MILLISECOND -> ChronoUnit.MILLIS;
-            case SECOND -> ChronoUnit.SECONDS;
-            case MINUTE -> ChronoUnit.MINUTES;
-            case HOUR -> ChronoUnit.HOURS;
-            case DAY -> ChronoUnit.DAYS;
-            case WEEK -> ChronoUnit.WEEKS;
-            case MONTH -> ChronoUnit.MONTHS;
-            case YEAR -> ChronoUnit.YEARS;
-        };
-        int calendarField = switch (getRepeatIntervalUnit()) {
-            case MILLISECOND -> Calendar.MILLISECOND;
-            case SECOND -> Calendar.SECOND;
-            case MINUTE -> Calendar.MINUTE;
-            case HOUR -> Calendar.HOUR_OF_DAY;
-            case DAY -> Calendar.DAY_OF_YEAR;
-            case WEEK -> Calendar.WEEK_OF_YEAR;
-            case MONTH -> Calendar.MONTH;
-            case YEAR -> Calendar.YEAR;
-        };
+        final ChronoUnit chronoUnit;
+        switch (getRepeatIntervalUnit()) {
+            case MILLISECOND: chronoUnit = ChronoUnit.MILLIS; break;
+            case SECOND: chronoUnit = ChronoUnit.SECONDS; break;
+            case MINUTE: chronoUnit = ChronoUnit.MINUTES; break;
+            case HOUR: chronoUnit = ChronoUnit.HOURS; break;
+            case DAY: chronoUnit = ChronoUnit.DAYS; break;
+            case WEEK: chronoUnit = ChronoUnit.WEEKS; break;
+            case MONTH: chronoUnit = ChronoUnit.MONTHS; break;
+            case YEAR:
+            default: chronoUnit = ChronoUnit.YEARS; break;
+        }
+        final int calendarField;
+        switch (getRepeatIntervalUnit()) {
+            case MILLISECOND: calendarField = Calendar.MILLISECOND; break;
+            case SECOND: calendarField = Calendar.SECOND; break;
+            case MINUTE: calendarField = Calendar.MINUTE; break;
+            case HOUR: calendarField = Calendar.HOUR_OF_DAY; break;
+            case DAY: calendarField = Calendar.DAY_OF_YEAR; break;
+            case WEEK: calendarField = Calendar.WEEK_OF_YEAR; break;
+            case MONTH: calendarField = Calendar.MONTH; break;
+            case YEAR:
+            default: calendarField = Calendar.YEAR; break;
+        }
 
         final long unitsSinceStart;
         if(chronoUnit.compareTo(ChronoUnit.DAYS) > 0) {
@@ -815,15 +819,17 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
         lTime.setTime(fTime);
         lTime.setLenient(true);
 
-        int calendarField = switch (getRepeatIntervalUnit()) {
-            case MILLISECOND -> Calendar.MILLISECOND;
-            case SECOND -> Calendar.SECOND;
-            case MINUTE -> Calendar.MINUTE;
-            case HOUR -> Calendar.HOUR_OF_DAY;
-            case DAY -> Calendar.DAY_OF_YEAR;
-            case WEEK -> Calendar.WEEK_OF_YEAR;
-            case MONTH -> Calendar.MONTH;
-            case YEAR -> Calendar.YEAR;
+        final int calendarField;
+        switch (getRepeatIntervalUnit()) {
+            case MILLISECOND: calendarField = Calendar.MILLISECOND; break;
+            case SECOND: calendarField = Calendar.SECOND; break;
+            case MINUTE: calendarField = Calendar.MINUTE; break;
+            case HOUR: calendarField = Calendar.HOUR_OF_DAY; break;
+            case DAY: calendarField = Calendar.DAY_OF_YEAR; break;
+            case WEEK: calendarField = Calendar.WEEK_OF_YEAR; break;
+            case MONTH: calendarField = Calendar.MONTH; break;
+            case YEAR:
+            default: calendarField = Calendar.YEAR;
         };
         lTime.add(calendarField, -1 * getRepeatInterval());
 

--- a/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
+++ b/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
@@ -753,7 +753,7 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
         final ZoneId zoneId = timeZone == null ? ZoneId.systemDefault() : timeZone.toZoneId();
         final ZonedDateTime aDateTime = ZonedDateTime.ofInstant(afterTime.toInstant(), zoneId);
         final ZonedDateTime sDateTime = ZonedDateTime.ofInstant(startTime.toInstant(), zoneId);
-        final long unitsSinceStart = chronoUnit.between(aDateTime, sDateTime);
+        final long unitsSinceStart = chronoUnit.between(sDateTime, aDateTime);
 
         Supplier<ZonedDateTime> advancer = new Supplier<>() {
             private int intervalUnitsSinceStart = getRepeatInterval() * (int)(unitsSinceStart / getRepeatInterval());

--- a/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
+++ b/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
@@ -750,11 +750,10 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
 
         final ChronoUnit chronoUnit = intervalUnitToChronoUnit();
 
-        final long unitsSinceStart;
-        ZoneId zoneId = timeZone == null ? ZoneId.systemDefault() : timeZone.toZoneId();
+        final ZoneId zoneId = timeZone == null ? ZoneId.systemDefault() : timeZone.toZoneId();
         final ZonedDateTime aDateTime = ZonedDateTime.ofInstant(afterTime.toInstant(), zoneId);
         final ZonedDateTime sDateTime = ZonedDateTime.ofInstant(startTime.toInstant(), zoneId);
-        unitsSinceStart = chronoUnit.between(aDateTime, sDateTime);
+        final long unitsSinceStart = chronoUnit.between(aDateTime, sDateTime);
 
         Supplier<ZonedDateTime> advancer = new Supplier<>() {
             private int intervalUnitsSinceStart = getRepeatInterval() * (int)(unitsSinceStart / getRepeatInterval());

--- a/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
+++ b/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
@@ -664,6 +664,52 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
         this.previousFireTime = previousFireTime;
     }
 
+    private ChronoUnit intervalUnitToChronoUnit() {
+        switch (getRepeatIntervalUnit()) {
+            case MILLISECOND:
+                return ChronoUnit.MILLIS;
+            case SECOND:
+                return ChronoUnit.SECONDS;
+            case MINUTE:
+                return ChronoUnit.MINUTES;
+            case HOUR:
+                return ChronoUnit.HOURS;
+            case DAY:
+                return ChronoUnit.DAYS;
+            case WEEK:
+                return ChronoUnit.WEEKS;
+            case MONTH:
+                return ChronoUnit.MONTHS;
+            case YEAR:
+                return ChronoUnit.YEARS;
+            default:
+                throw new IllegalStateException("Unknown repeat interval unit: " + getRepeatIntervalUnit());
+        }
+    }
+
+    private int intervalUnitToCalendarField() {
+        switch (getRepeatIntervalUnit()) {
+            case MILLISECOND:
+                return Calendar.MILLISECOND;
+            case SECOND:
+                return Calendar.SECOND;
+            case MINUTE:
+                return Calendar.MINUTE;
+            case HOUR:
+                return Calendar.HOUR_OF_DAY;
+            case DAY:
+                return Calendar.DAY_OF_YEAR;
+            case WEEK:
+                return Calendar.WEEK_OF_YEAR;
+            case MONTH:
+                return Calendar.MONTH;
+            case YEAR:
+                return Calendar.YEAR;
+            default:
+                throw new IllegalStateException("Unknown repeat interval unit: " + getRepeatIntervalUnit());
+        }
+    }
+
     /**
      * <p>
      * Returns the next time at which the <code>DateIntervalTrigger</code> will
@@ -710,30 +756,8 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
         sTime.setTime(getStartTime());
         sTime.setLenient(true);
 
-        final ChronoUnit chronoUnit;
-        switch (getRepeatIntervalUnit()) {
-            case MILLISECOND: chronoUnit = ChronoUnit.MILLIS; break;
-            case SECOND: chronoUnit = ChronoUnit.SECONDS; break;
-            case MINUTE: chronoUnit = ChronoUnit.MINUTES; break;
-            case HOUR: chronoUnit = ChronoUnit.HOURS; break;
-            case DAY: chronoUnit = ChronoUnit.DAYS; break;
-            case WEEK: chronoUnit = ChronoUnit.WEEKS; break;
-            case MONTH: chronoUnit = ChronoUnit.MONTHS; break;
-            case YEAR:
-            default: chronoUnit = ChronoUnit.YEARS; break;
-        }
-        final int calendarField;
-        switch (getRepeatIntervalUnit()) {
-            case MILLISECOND: calendarField = Calendar.MILLISECOND; break;
-            case SECOND: calendarField = Calendar.SECOND; break;
-            case MINUTE: calendarField = Calendar.MINUTE; break;
-            case HOUR: calendarField = Calendar.HOUR_OF_DAY; break;
-            case DAY: calendarField = Calendar.DAY_OF_YEAR; break;
-            case WEEK: calendarField = Calendar.WEEK_OF_YEAR; break;
-            case MONTH: calendarField = Calendar.MONTH; break;
-            case YEAR:
-            default: calendarField = Calendar.YEAR; break;
-        }
+        final ChronoUnit chronoUnit = intervalUnitToChronoUnit();
+        final int calendarField = intervalUnitToCalendarField();
 
         final long unitsSinceStart;
         if(chronoUnit.compareTo(ChronoUnit.DAYS) > 0) {
@@ -819,19 +843,7 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
         lTime.setTime(fTime);
         lTime.setLenient(true);
 
-        final int calendarField;
-        switch (getRepeatIntervalUnit()) {
-            case MILLISECOND: calendarField = Calendar.MILLISECOND; break;
-            case SECOND: calendarField = Calendar.SECOND; break;
-            case MINUTE: calendarField = Calendar.MINUTE; break;
-            case HOUR: calendarField = Calendar.HOUR_OF_DAY; break;
-            case DAY: calendarField = Calendar.DAY_OF_YEAR; break;
-            case WEEK: calendarField = Calendar.WEEK_OF_YEAR; break;
-            case MONTH: calendarField = Calendar.MONTH; break;
-            case YEAR:
-            default: calendarField = Calendar.YEAR;
-        };
-        lTime.add(calendarField, -1 * getRepeatInterval());
+        lTime.add(intervalUnitToCalendarField(), -1 * getRepeatInterval());
 
         return lTime.getTime();
     }

--- a/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
+++ b/quartz/src/main/java/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.java
@@ -19,12 +19,14 @@
 
 package org.quartz.impl.triggers;
 
-import java.time.LocalDateTime;
+import java.time.DateTimeException;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.function.Supplier;
 
 import org.quartz.CalendarIntervalScheduleBuilder;
 import org.quartz.CalendarIntervalTrigger;
@@ -698,7 +700,7 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
             case HOUR:
                 return Calendar.HOUR_OF_DAY;
             case DAY:
-                return Calendar.DAY_OF_YEAR;
+                return Calendar.DAY_OF_MONTH;
             case WEEK:
                 return Calendar.WEEK_OF_YEAR;
             case MONTH:
@@ -746,50 +748,41 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
             return new Date(startMillis);
         }
 
-        Calendar aTime = Calendar.getInstance();
-        aTime.setTime(afterTime);
-
-        Calendar sTime = Calendar.getInstance();
-        if(timeZone != null) {
-            sTime.setTimeZone(timeZone);
-        }
-        sTime.setTime(getStartTime());
-        sTime.setLenient(true);
-
         final ChronoUnit chronoUnit = intervalUnitToChronoUnit();
-        final int calendarField = intervalUnitToCalendarField();
 
         final long unitsSinceStart;
-        if(chronoUnit.compareTo(ChronoUnit.DAYS) > 0) {
-            ZoneId zoneId = sTime.getTimeZone().toZoneId();
-            LocalDateTime aDateTime = LocalDateTime.ofInstant(aTime.toInstant(), zoneId);
-            LocalDateTime sDateTime = LocalDateTime.ofInstant(sTime.toInstant(), zoneId);
-            unitsSinceStart = chronoUnit.between(aDateTime, sDateTime);
-        } else {
-            unitsSinceStart = chronoUnit.between(aTime.toInstant(), sTime.toInstant());
-        }
-        int intervalUnitsSinceStart = getRepeatInterval() * (int)(unitsSinceStart / getRepeatInterval());
-        int initialHourOfDay = -1;
-        if(chronoUnit.compareTo(ChronoUnit.DAYS) >= 0) {
-            initialHourOfDay = sTime.get(Calendar.HOUR_OF_DAY);
-        }
-        sTime.add(calendarField, intervalUnitsSinceStart);
-        while(!sTime.getTime().after(afterTime) &&
-            (sTime.get(Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {
-            sTime.setTime(getStartTime());
-            intervalUnitsSinceStart += getRepeatInterval();
-            sTime.add(calendarField, intervalUnitsSinceStart);
-        }
-        if(initialHourOfDay >= 0) {
-            while(daylightSavingHourShiftOccurredAndAdvanceNeeded(sTime, initialHourOfDay, afterTime) &&
-                    (sTime.get(Calendar.YEAR) < YEAR_TO_GIVEUP_SCHEDULING_AT)) {
-                sTime.setTime(getStartTime());
+        ZoneId zoneId = timeZone == null ? ZoneId.systemDefault() : timeZone.toZoneId();
+        final ZonedDateTime aDateTime = ZonedDateTime.ofInstant(afterTime.toInstant(), zoneId);
+        final ZonedDateTime sDateTime = ZonedDateTime.ofInstant(startTime.toInstant(), zoneId);
+        unitsSinceStart = chronoUnit.between(aDateTime, sDateTime);
+
+        Supplier<ZonedDateTime> advancer = new Supplier<>() {
+            private int intervalUnitsSinceStart = getRepeatInterval() * (int)(unitsSinceStart / getRepeatInterval());
+            @Override
+            public ZonedDateTime get() {
+                ZonedDateTime result = sDateTime.plus(intervalUnitsSinceStart, chronoUnit);
+                if(result.getYear() >= YEAR_TO_GIVEUP_SCHEDULING_AT) {
+                    return null;
+                }
                 intervalUnitsSinceStart += getRepeatInterval();
-                sTime.add(calendarField, intervalUnitsSinceStart);
+                return result;
             }
+        };
+
+        ZonedDateTime nextFireDateTime = advancer.get();
+        while(nextFireDateTime != null && !nextFireDateTime.isAfter(aDateTime)) {
+            nextFireDateTime = advancer.get();
         }
 
-        Date time = sTime.getTime();
+        if(nextFireDateTime != null && chronoUnit.compareTo(ChronoUnit.DAYS) >= 0) {
+            nextFireDateTime = advanceIfNeeded(nextFireDateTime, sDateTime, aDateTime, advancer);
+        }
+
+        if(nextFireDateTime == null) {
+            return null;
+        }
+
+        Date time = Date.from(nextFireDateTime.toInstant());
 
         if (!ignoreEndTime && (endMillis <= time.getTime())) {
             return null;
@@ -798,16 +791,36 @@ public class CalendarIntervalTriggerImpl extends AbstractTrigger<CalendarInterva
         return time;
     }
 
-    private boolean daylightSavingHourShiftOccurredAndAdvanceNeeded(Calendar newTime, int initialHourOfDay, Date afterTime) {
-        if(isPreserveHourOfDayAcrossDaylightSavings() && newTime.get(Calendar.HOUR_OF_DAY) != initialHourOfDay) {
-            newTime.set(Calendar.HOUR_OF_DAY, initialHourOfDay);
-            if (newTime.get(Calendar.HOUR_OF_DAY) != initialHourOfDay) {
-                return isSkipDayIfHourDoesNotExist();
-            } else {
-                return !newTime.getTime().after(afterTime);
+    private ZonedDateTime advanceIfNeeded(ZonedDateTime nextFireDateTime,
+                                          ZonedDateTime startDateTime,
+                                          ZonedDateTime afterDateTime,
+                                          Supplier<ZonedDateTime> advancer) {
+        if(isPreserveHourOfDayAcrossDaylightSavings()) {
+            int initialHourOfDay = startDateTime.getHour();
+            // This may iterate multiple times in the case of skipDayIfHourDoesNotExist and yearly intervals
+            while(nextFireDateTime != null && nextFireDateTime.getHour() != initialHourOfDay) {
+                ZonedDateTime adjustedDateTime;
+                try {
+                    adjustedDateTime = nextFireDateTime.withHour(initialHourOfDay);
+                } catch (DateTimeException ignored) {
+                    adjustedDateTime = nextFireDateTime;
+                }
+                if (adjustedDateTime.getHour() == initialHourOfDay) {
+                    if (adjustedDateTime.isAfter(afterDateTime)) {
+                        return adjustedDateTime;
+                    } else {
+                        nextFireDateTime = advancer.get();
+                    }
+                } else {
+                    if (isSkipDayIfHourDoesNotExist()) {
+                        nextFireDateTime = advancer.get();
+                    } else {
+                        return nextFireDateTime;
+                    }
+                }
             }
         }
-        return false;
+        return nextFireDateTime;
     }
     
     /**

--- a/quartz/src/test/java/org/quartz/CalendarIntervalTriggerTest.java
+++ b/quartz/src/test/java/org/quartz/CalendarIntervalTriggerTest.java
@@ -29,6 +29,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.quartz.DateBuilder.IntervalUnit;
@@ -122,11 +123,11 @@ public class CalendarIntervalTriggerTest  extends SerializationTestSupport {
         assertEquals(List.of(leapYear, leapYear + 1,leapYear + 2,leapYear + 3,leapYear + 4), fireTimes.stream()
             .peek(testCal::setTime)
             .map(d -> testCal.get(Calendar.YEAR))
-            .toList());
+            .collect(Collectors.toList()));
         assertEquals(List.of(29,28,28,28,29), fireTimes.stream()
             .peek(testCal::setTime)
             .map(d -> testCal.get(Calendar.DAY_OF_MONTH))
-            .toList());
+            .collect(Collectors.toList()));
     }
 
     @Test
@@ -169,7 +170,7 @@ public class CalendarIntervalTriggerTest  extends SerializationTestSupport {
         assertEquals(List.of(31,30,31), fireTimes.stream()
             .peek(testCal::setTime)
             .map(d -> testCal.get(Calendar.DAY_OF_MONTH))
-            .toList());
+            .collect(Collectors.toList()));
     }
 
     @Test
@@ -191,15 +192,15 @@ public class CalendarIntervalTriggerTest  extends SerializationTestSupport {
         assertEquals(List.of(1,2,3), fireTimes.stream()
             .peek(testCal::setTime)
             .map(d -> testCal.get(Calendar.MONTH))
-            .toList());
+            .collect(Collectors.toList()));
         assertEquals(List.of(9,9,9), fireTimes.stream()
             .peek(testCal::setTime)
             .map(d -> testCal.get(Calendar.DAY_OF_MONTH))
-            .toList());
+            .collect(Collectors.toList()));
         assertEquals(List.of(2,3,2), fireTimes.stream()
             .peek(testCal::setTime)
             .map(d -> testCal.get(Calendar.HOUR_OF_DAY))
-            .toList());
+            .collect(Collectors.toList()));
     }
 
     @Test
@@ -288,7 +289,10 @@ public class CalendarIntervalTriggerTest  extends SerializationTestSupport {
         List<Date> fireTimes = TriggerUtils.computeFireTimes(yearlyTrigger, null, 4);
 
         Calendar testCal = Calendar.getInstance(startCalendar.getTimeZone());
-        assertEquals(List.of(1,3,4,5), fireTimes.stream().peek(testCal::setTime).map(d -> testCal.get(Calendar.HOUR_OF_DAY)).toList());
+        assertEquals(List.of(1,3,4,5), fireTimes.stream()
+            .peek(testCal::setTime)
+            .map(d -> testCal.get(Calendar.HOUR_OF_DAY))
+            .collect(Collectors.toList()));
     }
 
     @Test

--- a/quartz/src/test/java/org/quartz/CalendarIntervalTriggerTest.java
+++ b/quartz/src/test/java/org/quartz/CalendarIntervalTriggerTest.java
@@ -24,9 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
 import java.text.ParseException;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.time.temporal.ChronoUnit;
 import java.time.zone.ZoneOffsetTransition;
 import java.time.zone.ZoneRules;
@@ -195,6 +193,7 @@ public class CalendarIntervalTriggerTest  extends SerializationTestSupport {
         Instant transitionInstant = transition.getInstant();
         cal.setTimeZone(TimeZone.getTimeZone(zoneId));
         cal.setTimeInMillis(transitionInstant.minus(30, ChronoUnit.MINUTES).toEpochMilli());
+        cal.setLenient(true);
         return cal;
     }
 
@@ -217,7 +216,8 @@ public class CalendarIntervalTriggerTest  extends SerializationTestSupport {
         List<Date> fireTimes = TriggerUtils.computeFireTimes(yearlyTrigger, null, 3);
 
         Calendar testCal = Calendar.getInstance(startCalendar.getTimeZone());
-        String hint = "Failed for " + startCalendar.getTime() + " in time zone " + startCalendar.getTimeZone().getID();
+        ZonedDateTime localDateTime = startCalendar.toInstant().atZone(startCalendar.getTimeZone().toZoneId());
+        String hint = "Failed for " + localDateTime;
         // Check that no month is skipped
         assertEquals(List.of(month, month + 1, month + 2), fireTimes.stream()
             .peek(testCal::setTime)
@@ -281,6 +281,76 @@ public class CalendarIntervalTriggerTest  extends SerializationTestSupport {
 
         assertEquals(targetCalendar.getTime(), fifthTime, "Day increment result not as expected.");
     }
+
+    @Test
+    void testDailyIntervalGetFireTimeAfterSpringForward() {
+        Calendar startCalendar = get30MinBeforeSpringForward();
+
+        startCalendar.add(Calendar.DAY_OF_MONTH, - 1);
+        startCalendar.add(Calendar.HOUR_OF_DAY, 1);
+        startCalendar.add(Calendar.MINUTE, 10);
+        int day = startCalendar.get(Calendar.DAY_OF_YEAR);
+        int hour = startCalendar.get(Calendar.HOUR_OF_DAY);
+
+        CalendarIntervalTriggerImpl yearlyTrigger = new CalendarIntervalTriggerImpl();
+        yearlyTrigger.setStartTime(startCalendar.getTime());
+        yearlyTrigger.setRepeatIntervalUnit(IntervalUnit.DAY);
+        yearlyTrigger.setRepeatInterval(1);
+        yearlyTrigger.setTimeZone(startCalendar.getTimeZone());
+
+        List<Date> fireTimes = TriggerUtils.computeFireTimes(yearlyTrigger, null, 3);
+
+        Calendar testCal = Calendar.getInstance(startCalendar.getTimeZone());
+        ZonedDateTime localDateTime = startCalendar.toInstant().atZone(startCalendar.getTimeZone().toZoneId());
+        String hint = "Failed for " + localDateTime;
+        // Check that no day is skipped
+        assertEquals(List.of(day, day + 1, day + 2), fireTimes.stream()
+            .peek(testCal::setTime)
+            .map(d -> testCal.get(Calendar.DAY_OF_YEAR))
+            .collect(Collectors.toList()), hint);
+        // Check that spring forward gap does not affect the following trigger times
+        assertEquals(List.of(hour, hour+1, hour), fireTimes.stream()
+            .peek(testCal::setTime)
+            .map(d -> testCal.get(Calendar.HOUR_OF_DAY))
+            .collect(Collectors.toList()), hint);
+    }
+
+    @Test
+    void testDailyIntervalGetFireTimeAfterSpringForwardPreserveHour() {
+        Calendar startCalendar = get30MinBeforeSpringForward();
+
+        startCalendar.add(Calendar.DAY_OF_MONTH, - 1);
+        startCalendar.add(Calendar.HOUR_OF_DAY, 1);
+        startCalendar.add(Calendar.MINUTE, 10);
+        int day = startCalendar.get(Calendar.DAY_OF_YEAR);
+        int hour = startCalendar.get(Calendar.HOUR_OF_DAY);
+
+        CalendarIntervalTriggerImpl yearlyTrigger = new CalendarIntervalTriggerImpl();
+        yearlyTrigger.setStartTime(startCalendar.getTime());
+        yearlyTrigger.setRepeatIntervalUnit(IntervalUnit.DAY);
+        yearlyTrigger.setRepeatInterval(1);
+        yearlyTrigger.setTimeZone(startCalendar.getTimeZone());
+
+        yearlyTrigger.setPreserveHourOfDayAcrossDaylightSavings(true);
+        yearlyTrigger.setSkipDayIfHourDoesNotExist(true);
+
+        List<Date> fireTimes = TriggerUtils.computeFireTimes(yearlyTrigger, null, 3);
+
+        Calendar testCal = Calendar.getInstance(startCalendar.getTimeZone());
+        ZonedDateTime localDateTime = startCalendar.toInstant().atZone(startCalendar.getTimeZone().toZoneId());
+        String hint = "Failed for " + localDateTime;
+        // Check that a DTS day got skipped
+        assertEquals(List.of(day, day + 2, day + 3), fireTimes.stream()
+            .peek(testCal::setTime)
+            .map(d -> testCal.get(Calendar.DAY_OF_YEAR))
+            .collect(Collectors.toList()), hint);
+        // Check that the hour is preserved
+        assertEquals(List.of(hour, hour, hour), fireTimes.stream()
+            .peek(testCal::setTime)
+            .map(d -> testCal.get(Calendar.HOUR_OF_DAY))
+            .collect(Collectors.toList()), hint);
+    }
+
     @Test
     void testHourlyIntervalGetFireTimeAfter() {
 
@@ -318,7 +388,8 @@ public class CalendarIntervalTriggerTest  extends SerializationTestSupport {
         yearlyTrigger.setRepeatInterval(1);
 
         List<Date> fireTimes = TriggerUtils.computeFireTimes(yearlyTrigger, null, 4);
-        String hint = "Failed for " + startCalendar.getTime() + " in time zone " + startCalendar.getTimeZone().getID();
+        ZonedDateTime localDateTime = startCalendar.toInstant().atZone(startCalendar.getTimeZone().toZoneId());
+        String hint = "Failed for " + localDateTime;
 
         Calendar testCal = Calendar.getInstance(startCalendar.getTimeZone());
         // Check that hourly firings are continuous across the spring forward gap


### PR DESCRIPTION
This PR addresses the following shortcomings with CalendarIntervalTriggerImpl.getFireTimeAfter(...):
- monthly trigger's firings starting on 31 day of month get shifted to 30th day and eventually to 28th day
- yearly trigger's firings starting on leap day of Feb 29 get shifted to 28th day of Feb
- daily trigger falling within gap daylight savings transition shifts forward by one hour following the transition

Fix #1352
Fix #1444 

## Changes
- refactored CalendarIntervalTriggerImpl.getFireTimeAfter to use LocalDateTime arithmetic 
- calculating next fire time relative to trigger's startTime rather than previous fire time, that addresses issues listed above
- added unit tests for the use cases that are being addresses

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs - NA
- [x] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

