### PR TITLE
Fix interval calculation for hourly triggers (2.4.x backport)

### DIFF
--- a/quartz/src/main/java/org/quartz/DailyTimeIntervalScheduleBuilder.java
+++ b/quartz/src/main/java/org/quartz/DailyTimeIntervalScheduleBuilder.java
@@ -332,7 +332,7 @@ public class DailyTimeIntervalScheduleBuilder extends ScheduleBuilder<DailyTimeI
         else if (intervalUnit == IntervalUnit.MINUTE)
                 intervalInMillis = interval * 1000L * 60;
         else if (intervalUnit == IntervalUnit.HOUR)
-            intervalInMillis = interval * 1000L * 60 * 24;
+            intervalInMillis = interval * 1000L * 60 * 60;
         else
             throw new IllegalArgumentException("The IntervalUnit: " + intervalUnit + " is invalid for this trigger."); 
         


### PR DESCRIPTION
There are 60*60 seconds in an hour

Fix #1428


see: https://github.com/quartz-scheduler/quartz/pull/1426


## Changes
- update milliseconds per hour calculation

-----------------
## Checklist
- [ ] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

