### PR TITLE
build(deps): update gradle wrapper to 9.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ allprojects {
             TaskProvider<WriteProperties> pomPropertiesTask = project.getTasks().register(pomTask.getName().replace("PomFile", "PomProperties"), WriteProperties.class, task -> {
                 task.dependsOn(pomTask);
                 task.setGroup(PUBLISH_TASK_GROUP);
-                task.setOutputFile(new File(pomTask.getDestination().getParentFile(), "pom.properties"));
+                task.getDestinationFile().set(new File(pomTask.getDestination().getParentFile(), "pom.properties"));
                 task.property("groupId", coordinates.getGroupId());
                 task.property("artifactId", coordinates.getArtifactId());
                 task.property("version", coordinates.getVersion());

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/quartz/build.gradle
+++ b/quartz/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.5.6'
     testImplementation 'org.postgresql:postgresql:42.7.8'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@
 pluginManagement {
     plugins {
         id("io.github.gradle-nexus.publish-plugin") version '2.0.0'
-        id ("biz.aQute.bnd.builder") version '6.4.0'
+        id ("biz.aQute.bnd.builder") version '7.2.1'
     }
 }
 
@@ -12,4 +12,3 @@ include 'quartz-stubs'
 include 'quartz-jobs'
 include 'quartz'
 include 'examples'
-


### PR DESCRIPTION
This PR updates gradle wrapper to 9.3.1. 

## Changes
 - add junit-plaform to quartz test classpath
 - use getDestinationFile() when configuring WriteProperties
 - update biz.aQute.bnd.builder plugin version

-----------------
## Checklist
- [x] tested locally
- [ ] updated the docs
- [ ] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )
-----------------
In submitting this contribution, I agree to the terms of contributing as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

