### PR TITLE
Fix doCheckin ignoring obtainLock return value

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java
@@ -3259,17 +3259,15 @@ public abstract class JobStoreSupport implements JobStore, Constants {
             }
             
             if (firstCheckIn || (!failedRecords.isEmpty())) {
-                getLockHandler().obtainLock(conn, LOCK_STATE_ACCESS);
-                transStateOwner = true;
+                transStateOwner = getLockHandler().obtainLock(conn, LOCK_STATE_ACCESS);
     
                 // Now that we own the lock, make sure we still have work to do. 
                 // The first time through, we also need to make sure we update/create our state record
                 failedRecords = (firstCheckIn) ? clusterCheckIn(conn) : findFailedInstances(conn);
     
                 if (!failedRecords.isEmpty()) {
-                    getLockHandler().obtainLock(conn, LOCK_TRIGGER_ACCESS);
+                    transOwner = getLockHandler().obtainLock(conn, LOCK_TRIGGER_ACCESS);
                     //getLockHandler().obtainLock(conn, LOCK_JOB_ACCESS);
-                    transOwner = true;
     
                     clusterRecover(conn, failedRecords);
                     recovered = true;


### PR DESCRIPTION
## Summary
- `doCheckin` was discarding the `boolean` return value of `obtainLock()`, unconditionally setting `transStateOwner`/`transOwner` to `true` regardless of whether the lock was actually acquired
- When `obtainLock` returns `false`, the subsequent `releaseLock` call produces a spurious `"attempt to return -- but not owner!"` warning
- This is consistent with other call sites in the same class (e.g. `recoverMisfiredJobs`, `executeInNonManagedTXLock`) which correctly capture the return value

Port of the equivalent fix from Quartz.NET: https://github.com/quartznet/quartznet/pull/2876

## Test plan
- [ ] Existing tests pass — this is a minimal, safe change that only affects the return value assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)