### PR TITLE
Harden JDBCJobStore deserialization: centralize getObjectFromBlob and support a JEP-290 ObjectInputFilter

### DIFF
--- a/examples/src/main/resources/org/quartz/examples/example13/instance1.properties
+++ b/examples/src/main/resources/org/quartz/examples/example13/instance1.properties
@@ -22,6 +22,13 @@ org.quartz.jobStore.misfireThreshold: 60000
 
 org.quartz.jobStore.class=org.quartz.impl.jdbcjobstore.JobStoreTX
 org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+
+# Optional: restrict which classes JDBCJobStore will deserialize from the database
+# (job data maps, triggers, calendars) using a JEP-290 look-ahead ObjectInputFilter.
+# It is off by default; when enabled, only classes matching the pattern are allowed.
+# Tailor the allow-list to the classes your jobs actually persist, then reject the
+# rest with "!*". The value uses java.io.ObjectInputFilter pattern syntax, e.g.:
+#org.quartz.jobStore.driverDelegateInitString=objectInputFilter=java.lang.*;java.util.*;org.quartz.**;com.myapp.jobs.**;!*
 org.quartz.jobStore.useProperties=false
 org.quartz.jobStore.dataSource=myDS
 org.quartz.jobStore.tablePrefix=QRTZ_

--- a/examples/src/main/resources/org/quartz/examples/example13/instance2.properties
+++ b/examples/src/main/resources/org/quartz/examples/example13/instance2.properties
@@ -22,6 +22,13 @@ org.quartz.jobStore.misfireThreshold: 60000
 
 org.quartz.jobStore.class=org.quartz.impl.jdbcjobstore.JobStoreTX
 org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+
+# Optional: restrict which classes JDBCJobStore will deserialize from the database
+# (job data maps, triggers, calendars) using a JEP-290 look-ahead ObjectInputFilter.
+# It is off by default; when enabled, only classes matching the pattern are allowed.
+# Tailor the allow-list to the classes your jobs actually persist, then reject the
+# rest with "!*". The value uses java.io.ObjectInputFilter pattern syntax, e.g.:
+#org.quartz.jobStore.driverDelegateInitString=objectInputFilter=java.lang.*;java.util.*;org.quartz.**;com.myapp.jobs.**;!*
 org.quartz.jobStore.useProperties=false
 org.quartz.jobStore.dataSource=myDS
 org.quartz.jobStore.tablePrefix=QRTZ_

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/CUBRIDDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/CUBRIDDelegate.java
@@ -58,9 +58,7 @@ public class CUBRIDDelegate extends StdJDBCDelegate {
         if (bytes != null && bytes.length != 0) {
             binaryInput = new ByteArrayInputStream(bytes);
 
-            try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-                obj = in.readObject();
-            }
+            obj = readObjectFromBinaryStream(binaryInput);
         }
 
         return obj;

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/CacheDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/CacheDelegate.java
@@ -22,7 +22,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.sql.Blob;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -80,9 +79,7 @@ public class CacheDelegate extends StdJDBCDelegate {
                     } else if (binaryInput instanceof ByteArrayInputStream && ((ByteArrayInputStream) binaryInput).available() == 0 ) {
                         return null;
                     } else {
-                        try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-                            return in.readObject();
-                        }
+                        return readObjectFromBinaryStream(binaryInput);
                     }
                 }
             } finally {

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/GaussDBDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/GaussDBDelegate.java
@@ -21,7 +21,6 @@ package org.quartz.impl.jdbcjobstore;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -68,9 +67,7 @@ public class GaussDBDelegate extends StdJDBCDelegate {
         if(bytes != null && bytes.length != 0) {
             binaryInput = new ByteArrayInputStream(bytes);
 
-            try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-                obj = in.readObject();
-            }
+            obj = readObjectFromBinaryStream(binaryInput);
 
         }
         

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/HSQLDBDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/HSQLDBDelegate.java
@@ -21,7 +21,6 @@ package org.quartz.impl.jdbcjobstore;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -67,9 +66,7 @@ public class HSQLDBDelegate extends StdJDBCDelegate {
         
         Object obj;
 
-        try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-            obj = in.readObject();
-        }
+        obj = readObjectFromBinaryStream(binaryInput);
 
         return obj;
     }

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/MSSQLDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/MSSQLDelegate.java
@@ -22,7 +22,6 @@ import static org.quartz.TriggerKey.triggerKey;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -74,9 +73,7 @@ public class MSSQLDelegate extends StdJDBCDelegate {
 
         Object obj;
 
-        try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-            obj = in.readObject();
-        }
+        obj = readObjectFromBinaryStream(binaryInput);
 
         return obj;
     }

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PointbaseDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PointbaseDelegate.java
@@ -22,7 +22,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -410,9 +409,7 @@ public class PointbaseDelegate extends StdJDBCDelegate {
         InputStream binaryInput = new ByteArrayInputStream(binaryData);
 
         if (binaryInput.available() != 0) {
-            try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-                obj = in.readObject();
-            }
+            obj = readObjectFromBinaryStream(binaryInput);
         }
 
         return obj;

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PostgreSQLDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/PostgreSQLDelegate.java
@@ -21,7 +21,6 @@ package org.quartz.impl.jdbcjobstore;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -66,9 +65,7 @@ public class PostgreSQLDelegate extends StdJDBCDelegate {
         if(bytes != null && bytes.length != 0) {
             binaryInput = new ByteArrayInputStream(bytes);
 
-            try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-                obj = in.readObject();
-            }
+            obj = readObjectFromBinaryStream(binaryInput);
 
         }
         

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.NotSerializableException;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
@@ -96,7 +97,16 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
     protected String schedName;
 
     protected boolean useProperties;
-    
+
+    /**
+     * Optional look-ahead deserialization filter (JEP 290) applied to every object
+     * read back from a JDBCJobStore BLOB (job data map, trigger, calendar). Configured
+     * via the delegate init-string setting {@code objectInputFilter=<pattern>} (see
+     * {@link #initialize}). When {@code null} (the default), deserialization behavior
+     * is unchanged.
+     */
+    protected ObjectInputFilter objectInputFilter;
+
     protected ClassLoadHelper classLoadHelper;
 
     protected final List<TriggerPersistenceDelegate> triggerPersistenceDelegates = new LinkedList<>();
@@ -148,7 +158,7 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
         String[] settings = initString.split("\\|");
         
         for(String setting: settings) {
-            String[] parts = setting.split("=");
+            String[] parts = setting.split("=", 2);
             String name = parts[0];
             if(parts.length == 1 || parts[1] == null || parts[1].isEmpty())
                 continue;
@@ -164,6 +174,9 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
                         throw new NoSuchDelegateException("Error instantiating TriggerPersistenceDelegate of type: " + trigDelClassName, e);
                     } 
                 }
+            }
+            else if(name.equals("objectInputFilter")) {
+                this.objectInputFilter = ObjectInputFilter.Config.createFilter(parts[1]);
             }
             else
                 throw new NoSuchDelegateException("Unknown setting: '" + name + "'");
@@ -3420,14 +3433,39 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
                     && ((ByteArrayInputStream) binaryInput).available() == 0 ) {
                     //do nothing
                 } else {
-                    try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-                        obj = in.readObject();
-                    }
+                    obj = readObjectFromBinaryStream(binaryInput);
                 }
             }
 
         }
         return obj;
+    }
+
+    /**
+     * Deserialize an object from the given binary stream, applying the configured
+     * {@link ObjectInputFilter} (if any) as a look-ahead deserialization guard
+     * (JEP 290). This is the single choke point through which every JDBCJobStore
+     * BLOB (job data map, trigger, calendar) is deserialized, so that a filter can
+     * be enforced consistently across the base delegate and every database-specific
+     * subclass rather than being duplicated (or omitted) per delegate. When no
+     * filter is configured, behavior is identical to a plain {@code ObjectInputStream}.
+     *
+     * @param binaryInput
+     *          the stream containing the serialized object
+     * @return the deserialized Object
+     * @throws ClassNotFoundException
+     *           if a class found during deserialization cannot be found
+     * @throws IOException
+     *           if deserialization causes an error (including rejection by the filter)
+     */
+    protected Object readObjectFromBinaryStream(InputStream binaryInput)
+        throws ClassNotFoundException, IOException {
+        try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
+            if (objectInputFilter != null) {
+                in.setObjectInputFilter(objectInputFilter);
+            }
+            return in.readObject();
+        }
     }
 
     /**

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/SybaseDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/SybaseDelegate.java
@@ -21,7 +21,6 @@ package org.quartz.impl.jdbcjobstore;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -69,9 +68,7 @@ public class SybaseDelegate extends StdJDBCDelegate {
 
         Object obj;
 
-        try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-            obj = in.readObject();
-        }
+        obj = readObjectFromBinaryStream(binaryInput);
 
         return obj;
     }

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/WebLogicDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/WebLogicDelegate.java
@@ -20,7 +20,6 @@ package org.quartz.impl.jdbcjobstore;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.sql.Blob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -72,9 +71,7 @@ public class WebLogicDelegate extends StdJDBCDelegate {
         }
 
         if (null != binaryInput) {
-            try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-                obj = in.readObject();
-            }
+            obj = readObjectFromBinaryStream(binaryInput);
         }
 
         return obj;

--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/oracle/OracleDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/oracle/OracleDelegate.java
@@ -21,7 +21,6 @@ package org.quartz.impl.jdbcjobstore.oracle;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.math.BigDecimal;
 import java.sql.Blob;
 import java.sql.Connection;
@@ -135,9 +134,7 @@ public class OracleDelegate extends StdJDBCDelegate {
         Object obj = null;
         InputStream binaryInput = rs.getBinaryStream(colName);
         if (binaryInput != null) {
-            try (ObjectInputStream in = new ObjectInputStream(binaryInput)) {
-                obj = in.readObject();
-            }
+            obj = readObjectFromBinaryStream(binaryInput);
         }
 
         return obj;

--- a/quartz/src/test/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegateTest.java
+++ b/quartz/src/test/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegateTest.java
@@ -27,8 +27,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InvalidClassException;
 import java.io.NotSerializableException;
+import java.io.ObjectOutputStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -70,6 +76,49 @@ public class StdJDBCDelegateTest  {
         } catch (NotSerializableException e) {
             assertTrue(e.getMessage().indexOf("key3") >= 0);
         }
+    }
+
+    @Test
+    void testReadObjectFromBinaryStreamWithoutFilterIsBehaviorPreserving() throws Exception {
+        StdJDBCDelegate delegate = new StdJDBCDelegate();
+        delegate.initialize(LoggerFactory.getLogger(getClass()), "QRTZ_", "TESTSCHED", "INSTANCE", new SimpleClassLoadHelper(), false, "");
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("key", "value");
+        data.put("count", 42);
+
+        Object read = delegate.readObjectFromBinaryStream(new ByteArrayInputStream(serialize(data)));
+        assertEquals(data, read);
+    }
+
+    @Test
+    void testReadObjectFromBinaryStreamAppliesConfiguredFilter() throws Exception {
+        StdJDBCDelegate delegate = new StdJDBCDelegate();
+        // Restrict deserialization to the JDK types a job-data map round-trips, rejecting anything else.
+        delegate.initialize(LoggerFactory.getLogger(getClass()), "QRTZ_", "TESTSCHED", "INSTANCE", new SimpleClassLoadHelper(), false,
+                "objectInputFilter=java.util.*;java.lang.*;!*");
+
+        // A legitimate, allow-listed payload still deserializes unchanged.
+        Map<String, Object> data = new HashMap<>();
+        data.put("key", "value");
+        assertEquals(data, delegate.readObjectFromBinaryStream(new ByteArrayInputStream(serialize(data))));
+
+        // A class outside the allow-list is rejected by the filter before it is constructed.
+        byte[] disallowed = serialize(new UnexpectedType());
+        assertThrows(InvalidClassException.class,
+                () -> delegate.readObjectFromBinaryStream(new ByteArrayInputStream(disallowed)));
+    }
+
+    private static byte[] serialize(Object obj) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(obj);
+        }
+        return baos.toByteArray();
+    }
+
+    private static class UnexpectedType implements java.io.Serializable {
+        private static final long serialVersionUID = 1L;
     }
 
     @Test


### PR DESCRIPTION
## Summary

This centralizes the `JDBCJobStore` BLOB deserialization behind a single helper and adds support for a configurable JEP-290 `ObjectInputFilter`, so the job-data-map / trigger / calendar deserialization can be constrained in one place instead of being an unfiltered `new ObjectInputStream(...).readObject()` duplicated across the base delegate and every dialect delegate (CWE-502 hardening).

Discussion / design question (default policy): see the linked issue. **Opening as a draft**: the default is left as opt-in (no behavior change) pending the team's preference on the default filter policy.

## Changes

- Add `StdJDBCDelegate.readObjectFromBinaryStream(InputStream)`, the single choke point that constructs the `ObjectInputStream`, applies the configured `ObjectInputFilter` (if any), and reads the object.
- Route the base `getObjectFromBlob()` and all ten dialect overrides (`PostgreSQLDelegate`, `MSSQLDelegate`, `OracleDelegate`, `HSQLDBDelegate`, `SybaseDelegate`, `WebLogicDelegate`, `PointbaseDelegate`, `CUBRIDDelegate`, `CacheDelegate`, `GaussDBDelegate`) through it. Each delegate keeps its own dialect-specific stream fetching; only the deserialization step is shared.
- Add an optional `objectInputFilter` field, configurable via the delegate init-string setting `objectInputFilter=<JEP-290 pattern>` (parsed with `ObjectInputFilter.Config.createFilter`). The init-string split is changed to `split("=", 2)` so filter patterns (which contain `=`) survive parsing.
- No new dependencies (`java.io.ObjectInputFilter` is JDK 9+, this project targets Java 11).

## Behavior

- **Default is unchanged.** With no `objectInputFilter` configured, the field is `null` and deserialization behaves exactly as before.
- When configured (e.g. `org.quartz.jobStore.driverDelegateInitString = objectInputFilter=maxdepth=20;java.**;org.quartz.**;!*`), the filter is applied at the single choke point for every BLOB the store reads back.

## Testing

- `./gradlew :quartz:compileJava` succeeds on the Java 11 toolchain.
- `./gradlew :quartz:test --tests StdJDBCDelegateTest`: 7 passed, 0 failed. Two tests were added:
  - `testReadObjectFromBinaryStreamWithoutFilterIsBehaviorPreserving`: legitimate map round-trips unchanged with no filter.
  - `testReadObjectFromBinaryStreamAppliesConfiguredFilter`: a legitimate map still deserializes, while a class outside the configured allow-list is rejected (`InvalidClassException`).

## Notes

Commits are DCO signed-off. This is a draft pending the default-policy discussion in the linked issue; happy to adjust the default (opt-in vs. a non-breaking resource-limit default vs. a reject-list) before finalizing.
