### PR TITLE
Fix JDBC trigger replace when trigger type changes

### DIFF
--- a/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
+++ b/quartz/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java
@@ -1232,11 +1232,17 @@ public class StdJDBCDelegate implements DriverDelegate, StdJDBCConstants {
             }
 
             insertResult = ps.executeUpdate();
-            
+
+            // Extended properties live in type-specific tables (SIMPLE/CRON/...).
+            // updateExtendedTriggerProperties only updates the new type's table, so a
+            // replace that changes trigger type (e.g. SIMPLE -> CRON) leaves the old
+            // extension row behind and inserts nothing into the new table. Always
+            // replace extended rows via delete + insert. See #920.
+            deleteTriggerExtension(conn, trigger.getKey());
             if(tDel == null)
-                updateBlobTrigger(conn, trigger);
+                insertBlobTrigger(conn, trigger);
             else
-                tDel.updateExtendedTriggerProperties(conn, trigger, state, jobDetail);
+                tDel.insertExtendedTriggerProperties(conn, trigger, state, jobDetail);
             
         } finally {
             closeStatement(ps);

--- a/quartz/src/test/java/org/quartz/AbstractJobStoreTest.java
+++ b/quartz/src/test/java/org/quartz/AbstractJobStoreTest.java
@@ -749,6 +749,55 @@ public abstract class AbstractJobStoreTest  {
     }
 
 
+    /**
+     * Replacing an existing trigger with one of a different concrete type must
+     * rewrite extended trigger rows (e.g. SIMPLE -> CRON). Otherwise the base
+     * QRTZ_TRIGGERS.TRIGGER_TYPE is updated while the old extension row remains
+     * and the new type's extension table is empty, corrupting subsequent reads.
+     *
+     * @see <a href="https://github.com/quartz-scheduler/quartz/issues/920">#920</a>
+     */
+    @Test
+    void testStoreTriggerReplaceChangesTriggerType() throws Exception {
+        Date start = new Date();
+        OperableTrigger simple = new SimpleTriggerImpl(
+                "typeChangeTrigger", "typeChangeGroup",
+                this.fJobDetail.getName(), this.fJobDetail.getGroup(),
+                start, null, SimpleTrigger.REPEAT_INDEFINITELY, 400_000L);
+        this.fJobStore.storeTrigger(simple, false);
+
+        OperableTrigger loadedSimple = this.fJobStore.retrieveTrigger(simple.getKey());
+        assertNotNull(loadedSimple);
+        assertTrue(loadedSimple instanceof SimpleTrigger);
+
+        OperableTrigger cron = (OperableTrigger) TriggerBuilder.newTrigger()
+                .withIdentity(simple.getKey())
+                .forJob(this.fJobDetail)
+                .withSchedule(CronScheduleBuilder.cronSchedule("0 0 12 * * ?"))
+                .startAt(start)
+                .build();
+
+        assertDoesNotThrow(() -> this.fJobStore.storeTrigger(cron, true));
+
+        OperableTrigger reloaded = this.fJobStore.retrieveTrigger(simple.getKey());
+        assertNotNull(reloaded, "trigger must remain readable after type-changing replace");
+        assertTrue(reloaded instanceof CronTrigger, "replaced trigger should be stored as CronTrigger");
+        assertEquals("0 0 12 * * ?", ((CronTrigger) reloaded).getCronExpression());
+
+        // Reverse direction: CRON -> SIMPLE
+        OperableTrigger simpleAgain = new SimpleTriggerImpl(
+                simple.getKey().getName(), simple.getKey().getGroup(),
+                this.fJobDetail.getName(), this.fJobDetail.getGroup(),
+                start, null, 3, 60_000L);
+        assertDoesNotThrow(() -> this.fJobStore.storeTrigger(simpleAgain, true));
+
+        OperableTrigger reloadedSimple = this.fJobStore.retrieveTrigger(simple.getKey());
+        assertNotNull(reloadedSimple);
+        assertTrue(reloadedSimple instanceof SimpleTrigger);
+        assertEquals(3, ((SimpleTrigger) reloadedSimple).getRepeatCount());
+        assertEquals(60_000L, ((SimpleTrigger) reloadedSimple).getRepeatInterval());
+    }
+
     @Test
     void testStoreJobReplacesJob() throws Exception {
 


### PR DESCRIPTION
This PR fixes JDBC job store corruption when an existing trigger is replaced with a different concrete type (for example SIMPLE -> CRON).

Fixes #920

## Changes
- In `StdJDBCDelegate.updateTrigger`, replace type-specific extended trigger rows with delete + insert instead of calling `updateExtendedTriggerProperties` alone
- Add regression coverage in `AbstractJobStoreTest.testStoreTriggerReplaceChangesTriggerType` (SIMPLE -> CRON and CRON -> SIMPLE)

## Why
`updateTrigger` already wrote the new `TRIGGER_TYPE` on `QRTZ_TRIGGERS`, but only ran `UPDATE` against the new extension table. That update affects 0 rows when the previous type differed, leaving the old extension row orphaned and making later `retrieveTrigger` fail with `NoRecordFoundException`.

## Checklist
- [x] tested locally
- [ ] updated the docs
- [x] added appropriate test
- [x] signed-off on the DCO referenced in the CONTRIBUTING link below via `git commit -s` on my commits, and submit this code under terms of the Apache 2.0 license and assign copyright to the Quartz project owners

## Test plan
Executed:
- `./gradlew :quartz:test --tests org.quartz.impl.jdbcjobstore.JdbcJobStoreTest.testStoreTriggerReplaceChangesTriggerType`
- `./gradlew :quartz:test --tests org.quartz.impl.jdbcjobstore.JdbcJobStoreTest --tests org.quartz.impl.jdbcjobstore.StdJDBCDelegateTest --tests org.quartz.impl.jdbcjobstore.DeleteNonExistsJobTest`

Both GREEN.

In submitting this contribution, I agree to the terms of contributing as referred to here:
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md