### PR TITLE
fix: getJobGroupsToNeverDelete/getTriggerGroupsToNeverDelete return wrong list

### DIFF
--- a/quartz/src/main/java/org/quartz/xml/XMLSchedulingDataProcessor.java
+++ b/quartz/src/main/java/org/quartz/xml/XMLSchedulingDataProcessor.java
@@ -317,7 +317,7 @@ public class XMLSchedulingDataProcessor implements ErrorHandler {
      * delete the group is encountered.
      */
     public List<String> getJobGroupsToNeverDelete() {
-        return Collections.unmodifiableList(jobGroupsToDelete);
+        return Collections.unmodifiableList(jobGroupsToNeverDelete);
     }
 
     /**
@@ -347,7 +347,7 @@ public class XMLSchedulingDataProcessor implements ErrorHandler {
      * delete the group is encountered.
      */
     public List<String> getTriggerGroupsToNeverDelete() {
-        return Collections.unmodifiableList(triggerGroupsToDelete);
+        return Collections.unmodifiableList(triggerGroupsToNeverDelete);
     }
     
     /*

--- a/quartz/src/test/java/org/quartz/xml/XMLSchedulingDataProcessorNeverDeleteTest.java
+++ b/quartz/src/test/java/org/quartz/xml/XMLSchedulingDataProcessorNeverDeleteTest.java
@@ -1,0 +1,38 @@
+package org.quartz.xml;
+
+import org.junit.jupiter.api.Test;
+import org.quartz.simpl.CascadingClassLoadHelper;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the *ToNeverDelete accessors return the correct backing list.
+ *
+ * @see <a href="https://github.com/quartz-scheduler/quartz/issues/1487">Issue #1487</a>
+ */
+public class XMLSchedulingDataProcessorNeverDeleteTest {
+    @Test
+    public void getJobGroupsToNeverDeleteReturnsAddedGroup() throws Exception {
+        XMLSchedulingDataProcessor processor = newProcessor();
+
+        processor.addJobGroupToNeverDelete("group1");
+        assertTrue(processor.getJobGroupsToNeverDelete().contains("group1"));
+        assertFalse(processor.getJobGroupsToNeverDelete().isEmpty());
+    }
+
+    @Test
+    public void getTriggerGroupsToNeverDeleteReturnsAddedGroup() throws Exception {
+        XMLSchedulingDataProcessor processor = newProcessor();
+
+        processor.addTriggerGroupToNeverDelete("tgroup1");
+        assertTrue(processor.getTriggerGroupsToNeverDelete().contains("tgroup1"));
+        assertFalse(processor.getTriggerGroupsToNeverDelete().isEmpty());
+    }
+
+    private static XMLSchedulingDataProcessor newProcessor() throws Exception {
+        CascadingClassLoadHelper clhelper = new CascadingClassLoadHelper();
+        clhelper.initialize();
+        return new XMLSchedulingDataProcessor(clhelper);
+    }
+}


### PR DESCRIPTION
## What
`getJobGroupsToNeverDelete()` and `getTriggerGroupsToNeverDelete()` now return the correct backing list.

## Why
The getter returned the `*ToDelete` list instead of `*ToNeverDelete`, so the matching `add*` / `remove*` methods (which operate on `*ToNeverDelete`) were invisible through the getter — `addJobGroupToNeverDelete("x")` followed by `getJobGroupsToNeverDelete().contains("x")` returned `false`. Issue #1487.

The same copy-paste bug existed in `getTriggerGroupsToNeverDelete`.

## Root cause
In `XMLSchedulingDataProcessor`:
- `addJobGroupToNeverDelete` / `removeJobGroupToNeverDelete` operate on `jobGroupsToNeverDelete`
- `getJobGroupsToNeverDelete` returned `Collections.unmodifiableList(jobGroupsToDelete)` ← the wrong list

(Same pattern for the trigger-group variants.)

## How
Return `jobGroupsToNeverDelete` / `triggerGroupsToNeverDelete` from the respective getters.

## Testing
- New `XMLSchedulingDataProcessorNeverDeleteTest`: `addJobGroupToNeverDelete` / `addTriggerGroupToNeverDelete`, then assert the getter contains the group.
- `./gradlew :quartz:test --tests XMLSchedulingDataProcessorNeverDeleteTest`: 2 tests pass.

Fixes #1487
